### PR TITLE
Streaming iterator: return slices on an internal buffer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -38,12 +38,11 @@ fn cli(params: Params) -> anyhow::Result<()> {
         args: params.args.clone(),
         run_timeout: params.run_timeout.into(),
         idle_timeout: params.idle_timeout.into(),
+        buffer_size: params.buffer_size,
     }
     .start()?;
 
-    let mut buffer = vec![0; params.buffer_size];
-
-    while let Some(event) = child.next(&mut buffer) {
+    while let Some(event) = child.next_event() {
         match event {
             command::Event::Stdout(output) => {
                 if !output.is_empty() && !log_enabled!(Trace) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn cli(params: Params) -> anyhow::Result<()> {
         out.unpause()?;
     }
 
-    let child = command::Command {
+    let mut child = command::Command {
         command: params.command.clone(),
         args: params.args.clone(),
         run_timeout: params.run_timeout.into(),
@@ -42,7 +42,7 @@ fn cli(params: Params) -> anyhow::Result<()> {
     }
     .start()?;
 
-    for event in child {
+    while let Some(event) = child.next() {
         match event {
             command::Event::Stdout(ref buffer) => {
                 if !buffer.is_empty() && !log_enabled!(Trace) {
@@ -82,7 +82,7 @@ fn cli(params: Params) -> anyhow::Result<()> {
         }
     }
 
-    unreachable!();
+    unreachable!("should have exited when child did");
 }
 
 fn init_logging(params: &Params) -> anyhow::Result<()> {


### PR DESCRIPTION
This avoids having to reallocate on every read event.