### PR TITLE
Add missing documentation and enable lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+#![warn(missing_docs)]
+//! Miscellaneous useful modules that support cron-wrapper.
+
+/// Read output from child process as events.
 pub mod command;
+
+/// Optionally buffer all writes to a stream until we decide to unpause it.
 pub mod pause_writer;
+
+/// Stateful timeouts.
 pub mod timeout;

--- a/src/pause_writer.rs
+++ b/src/pause_writer.rs
@@ -4,7 +4,11 @@ use std::io::Write;
 /// Whether a writer is running or paused.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum State {
+    /// The writer is paused. The content is a buffer containing all data
+    /// written while paused.
     Paused(Vec<u8>),
+
+    /// The writer is running. All writes go directly to the output stream.
     Running,
 }
 

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -30,18 +30,30 @@ pub enum Timeout {
     ///     Timeout::Future { .. } = Timeout::from(Duration::from_millis(100))
     /// );
     /// ```
-    Future { timeout: Duration },
+    Future {
+        /// The length of the timeout.
+        timeout: Duration,
+    },
 
-    /// A time out that is counting down.
+    /// A timeout that is counting down.
     ///
     /// Produced by [`Timeout::start()`].
-    Pending { timeout: Duration, start: Instant },
+    Pending {
+        /// The length of the timeout.
+        timeout: Duration,
 
-    /// A time out that has expired.
+        /// When the timeout started.
+        start: Instant,
+    },
+
+    /// A timeout that has expired.
     ///
     /// Produced by [`Timeout::check_expired()`].
     Expired {
+        /// The original length of the timeout.
         requested: Duration,
+
+        /// How much time actually elapsed before the operation was canceled.
         actual: Duration,
     },
 }


### PR DESCRIPTION
This enables the `missing_docs` lint for the entire crate.