### PR TITLE
Add ability to log job output with details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -197,9 +197,12 @@ dependencies = [
  "log",
  "nix",
  "popol",
+ "regex",
  "shell-words",
  "simplelog",
+ "tempfile",
  "thiserror",
+ "time",
 ]
 
 [[package]]
@@ -239,7 +242,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -250,6 +253,15 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -265,6 +277,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,7 +293,7 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -284,7 +305,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -437,10 +458,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rust_decimal"
@@ -463,7 +508,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -524,6 +569,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
 dependencies = [
  "itoa",
  "libc",
@@ -574,15 +632,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
 dependencies = [
  "time-core",
 ]
@@ -641,11 +699,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -654,14 +736,20 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -671,9 +759,21 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -683,9 +783,21 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -695,9 +807,21 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = []
 categories = [] # https://crates.io/category_slugs
 license = "MIT OR Apache-2.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 
 [dependencies]
 anyhow = "1.0.44"
@@ -23,8 +23,11 @@ popol = "2.0.0"
 shell-words = "1.1.0"
 simplelog = "0.12.0"
 thiserror = "1.0.40"
+time = { version = "0.3.21", features = ["local-offset", "formatting"] }
 
 [dev-dependencies]
 assert2 = "0.3.7"
 assert_cmd = "2.0.7"
 nix = { version = "0.26.1", default-features = false, features = ["signal", "process"] }
+regex = { version = "1.8.1", default-features = false, features = ["std"] }
+tempfile = "3.5.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ page][releases]. Just extract the archive and copy the file inside into your
 
 [![docs.rs](https://img.shields.io/docsrs/cron-wrapper)][docs.rs]
 [![Crates.io](https://img.shields.io/crates/v/cron-wrapper)][crates.io]
-![Rust version 1.60+](https://img.shields.io/badge/Rust%20version-1.60%2B-success)
+![Rust version 1.65+](https://img.shields.io/badge/Rust%20version-1.65%2B-success)
 
 ## Development status
 

--- a/src/job_logger.rs
+++ b/src/job_logger.rs
@@ -1,0 +1,384 @@
+use crate::command::{Child, Command, Event};
+use log::info;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, Write};
+use std::iter;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+use time::format_description::well_known::{iso8601, Iso8601};
+use time::OffsetDateTime;
+
+// Date and time format to use in log file names.
+const FILE_NAME_DATE_FORMAT: iso8601::EncodedConfig = iso8601::Config::DEFAULT
+    .set_time_precision(iso8601::TimePrecision::Second {
+        decimal_digits: None,
+    })
+    .encode();
+
+/// An object to optionally log all [`Event`]s from a [`Child`] to a file.
+///
+/// Example output format:
+///
+/// ```text
+/// Command: ["my-script.sh", "arg1", "arg2"]
+/// Start: 2023-05-15T18:31:41.509380000-07:00
+///
+/// +0.000 out foo bar hey
+///            next line whatever
+/// +0.010 err NOTICE bar hey
+/// +0.100 out mixed
+/// +0.200 \ out .
+/// +0.340 \ ERROR IdleTimeout { timeout: Expired { requested: 110ms, actual: 109.566826ms } }
+/// ```
+#[derive(Debug)]
+pub struct JobLogger {
+    start_instant: Instant,
+    start_time: OffsetDateTime,
+    destination: Destination,
+    command: Option<Command>,
+    child_id: Option<u32>,
+
+    /// If the last output from the child did *not* end with a newline.
+    continued_line: bool,
+}
+
+impl Default for JobLogger {
+    fn default() -> Self {
+        Self::none()
+    }
+}
+
+impl JobLogger {
+    /// Create a new job logger that will silently discard all logs.
+    pub fn none() -> Self {
+        JobLogger {
+            start_instant: Instant::now(),
+            start_time: OffsetDateTime::now_local()
+                .unwrap_or_else(|_| OffsetDateTime::now_utc()),
+            destination: Destination::None,
+            command: None,
+            child_id: None,
+            continued_line: false,
+        }
+    }
+
+    /// Create a new job logger that will store the log in a new file in the
+    /// passed directory.
+    ///
+    /// The directory must already exist.
+    pub fn new_in_directory<P: Into<PathBuf>>(path: P) -> Self {
+        let mut job_logger = Self::none();
+        job_logger.destination = Destination::Directory(path.into());
+        job_logger
+    }
+
+    /// Ensure the log file (if appropriate) is open.
+    ///
+    /// This returns `Ok(())` is the logger is configured with the `None`
+    /// destination.
+    pub fn ensure_open(&mut self) -> anyhow::Result<()> {
+        if let Destination::Directory(path) = &self.destination {
+            let path = path.join(self.generate_file_name()?);
+            let file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&path)?;
+            info!("Saving job output to {path:?}");
+            self.destination = Destination::File { path, file };
+            self.write_file_header()?;
+        }
+
+        Ok(())
+    }
+
+    /// Get the path to the log file, if available.
+    ///
+    /// You may wish to call [`Self::ensure_open()`] first to make sure that
+    /// the file has been created. If the logger was created by
+    /// [`Self::new_in_directory()`] but nothing has been logged, then the file
+    /// will not have been created and this will return `None`.
+    pub fn path(&self) -> Option<&Path> {
+        if let Destination::File { path, .. } = &self.destination {
+            Some(path)
+        } else {
+            None
+        }
+    }
+
+    /// Record the [`Command`] to run.
+    pub fn set_command(&mut self, command: &Command) {
+        self.command = Some(command.clone());
+    }
+
+    /// Record the PID of the [`Child`] that was spawned.
+    pub fn set_child(&mut self, child: &Child) {
+        self.child_id = Some(child.id());
+    }
+
+    /// Log an error originating in cron-wrapper, not an [`Event::Error`].
+    pub fn log_wrapper_error(
+        &mut self,
+        error: &anyhow::Error,
+    ) -> anyhow::Result<()> {
+        self.write_record("WRAPPER-ERROR", format!("{error:?}").as_bytes())
+    }
+
+    /// Log an [`Event`] received from the [`Child`].
+    pub fn log_event(&mut self, event: &Event) -> anyhow::Result<()> {
+        match &event {
+            Event::Stdout(output) => self.write_record("out", output),
+            Event::Stderr(output) => self.write_record("err", output),
+            Event::Exit(_) => {
+                if let Some(code) = event.exit_code() {
+                    self.write_record("exit", code.to_string().as_bytes())
+                } else {
+                    self.write_record("exit", b"none")
+                }
+            }
+            Event::Error(error) => {
+                self.write_record("ERROR", format!("{error:?}").as_bytes())
+            }
+        }
+    }
+
+    fn write_record(&mut self, kind: &str, value: &[u8]) -> anyhow::Result<()> {
+        let time = format!("{:.3}", self.elapsed());
+        let indent = time.len() + 5;
+        let value = self.escape(value, indent);
+
+        let mut buffer = vec![0u8; time.len() + kind.len() + value.len() + 5];
+        buffer.extend_from_slice(time.as_bytes());
+
+        if self.continued_line {
+            buffer.extend_from_slice(b" \\");
+        }
+
+        buffer.push(b' ');
+        buffer.extend_from_slice(kind.as_bytes());
+        buffer.push(b' ');
+        buffer.extend_from_slice(&value);
+        buffer.push(b'\n');
+
+        self.write_all(&buffer)
+    }
+
+    fn escape(&mut self, input: &[u8], indent: usize) -> Vec<u8> {
+        let indent: Vec<u8> = iter::repeat(b' ').take(indent).collect();
+        let mut output = vec![0u8; input.len()];
+        if let Some((&last, inpu)) = input.split_last() {
+            for &b in inpu {
+                output.push(b);
+                if b == b'\n' {
+                    output.extend_from_slice(&indent);
+                }
+            }
+
+            // FIXME? CR?
+            if last == b'\n' {
+                // Swallow trailing newline.
+                self.continued_line = false;
+            } else {
+                self.continued_line = true;
+                output.push(last);
+            }
+        }
+
+        output
+    }
+
+    /// Private: write raw data to `self.destination`.
+    fn write_all(&mut self, data: &[u8]) -> anyhow::Result<()> {
+        self.ensure_open()?;
+        Ok(self.destination.write_all(data)?)
+    }
+
+    /// Private: write standard header to log file.
+    fn write_file_header(&mut self) -> anyhow::Result<()> {
+        if let Some(command) = &self.command {
+            self.write_all(
+                format!(
+                    "Command: {:?}\n",
+                    command.command_line().collect::<Vec<_>>()
+                )
+                .as_bytes(),
+            )?;
+        }
+        let start = self.start_time.format(&Iso8601::DEFAULT)?;
+        self.write_all(format!("Start: {start}\n\n").as_bytes())
+    }
+
+    /// Private: generate a file name for a log.
+    fn generate_file_name(&self) -> anyhow::Result<OsString> {
+        let mut file_name = OsString::from(
+            self.start_time.format(&Iso8601::<FILE_NAME_DATE_FORMAT>)?,
+        );
+
+        let bin_name = self
+            .command
+            .as_ref()
+            .and_then(|command| command.command_as_path().file_name());
+
+        if let Some(bin_name) = bin_name {
+            file_name.push(".");
+            file_name.push(bin_name);
+        }
+
+        if let Some(child_id) = self.child_id {
+            file_name.push(".");
+            file_name.push(child_id.to_string());
+        }
+
+        file_name.push(".log");
+
+        Ok(file_name)
+    }
+
+    /// Private: get the seconds elapsed on the run.
+    fn elapsed(&self) -> f64 {
+        self.start_instant.elapsed().as_secs_f64()
+    }
+}
+
+/// Where logs should go.
+#[derive(Debug)]
+pub enum Destination {
+    /// Logs are discarded.
+    None,
+
+    /// Create a file in the passed directory once we receive our first log.
+    Directory(PathBuf),
+
+    /// An open file.
+    File {
+        /// Path to file.
+        path: PathBuf,
+
+        /// The actual open file.
+        file: fs::File,
+    },
+}
+
+impl Default for Destination {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl io::Write for Destination {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::None => Ok(buffer.len()),
+            Self::Directory(_) => {
+                panic!(
+                    "Cannot write to Destination::Directory. Use \
+                    into_writable() to get a writable destination."
+                );
+            }
+            Self::File { file, .. } => file.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::None => Ok(()),
+            Self::Directory(_) => {
+                panic!(
+                    "Cannot write to Destination::Directory. Use \
+                    into_writable() to get a writable destination."
+                );
+            }
+            Self::File { file, .. } => file.flush(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use assert2::check;
+    use regex::Regex;
+    use tempfile::tempdir;
+
+    /// Check the log file name for a logger.
+    ///
+    /// re can include special matchers:
+    ///   * <date> becomes [0-9]{4}-[0-9]{2}-[0-9]{2}
+    ///   * <time> becomes [0-9]{2}:[0-9]{2}:[0-9]{2}-[0-9]{2}:[0-9]{2}
+    fn check_file_name(logger: &JobLogger, re: &str) {
+        let path = logger.path().expect("no path to log file");
+        check!(path.exists());
+        let file_name = path.file_name().expect("log file path is not a file");
+        let file_name = file_name.to_string_lossy();
+
+        let re = re.replace("<date>", "[0-9]{4}-[0-9]{2}-[0-9]{2}").replace(
+            "<time>",
+            "[0-9]{2}:[0-9]{2}:[0-9]{2}(Z|-[0-9]{2}:[0-9]{2})",
+        );
+        let re = Regex::new(&re).unwrap();
+        check!(
+            re.is_match(file_name.as_ref()),
+            "log file name {file_name:?} does not match {re:?}"
+        );
+    }
+
+    #[test]
+    fn none_logger() {
+        let buffer = b"abc\n";
+
+        let mut logger = JobLogger::none();
+        check!(logger.log_event(&Event::Stdout(&buffer[..])).is_ok());
+        check!(logger.log_wrapper_error(&anyhow!("uh oh")).is_ok());
+    }
+
+    #[test]
+    fn directory_logger_no_metadata() {
+        let directory = tempdir().unwrap();
+        let buffer = b"abc\n";
+
+        let mut logger = JobLogger::new_in_directory(directory.path());
+        check!(logger.path().is_none());
+
+        check!(logger.log_event(&Event::Stdout(&buffer[..])).is_ok());
+        check!(logger.log_wrapper_error(&anyhow!("uh oh")).is_ok());
+
+        check_file_name(&logger, r"^<date>T<time>\.log$");
+    }
+
+    #[test]
+    fn directory_logger_with_command() {
+        let directory = tempdir().unwrap();
+        let buffer = b"abc\n";
+        let command = Command::new("/bin/ls", ["/"]);
+
+        let mut logger = JobLogger::new_in_directory(directory.path());
+        logger.set_command(&command);
+        check!(logger.path().is_none());
+
+        check!(logger.log_event(&Event::Stdout(&buffer[..])).is_ok());
+        check!(logger.log_wrapper_error(&anyhow!("uh oh")).is_ok());
+
+        check_file_name(&logger, r"^<date>T<time>\.ls\.log$");
+    }
+
+    #[test]
+    fn directory_logger_with_child() {
+        let directory = tempdir().unwrap();
+        let buffer = b"abc\n";
+        let command = Command::new("/bin/ls", ["/"]);
+        let mut child = command.spawn().unwrap();
+
+        let mut logger = JobLogger::new_in_directory(directory.path());
+        logger.set_command(&command);
+        logger.set_child(&child);
+        check!(logger.path().is_none());
+
+        let _ = child.process_mut().wait(); // Just for cleanliness.
+
+        check!(logger.log_event(&Event::Stdout(&buffer[..])).is_ok());
+        check!(logger.log_wrapper_error(&anyhow!("uh oh")).is_ok());
+
+        check_file_name(&logger, r"^<date>T<time>\.ls\.[0-9]+\.log$");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 /// Read output from child process as events.
 pub mod command;
 
+/// Log all events from a command.
+pub mod job_logger;
+
 /// Optionally buffer all writes to a stream until we decide to unpause it.
 pub mod pause_writer;
 

--- a/src/params.rs
+++ b/src/params.rs
@@ -30,6 +30,16 @@ pub(crate) struct Params {
     #[clap(short = 'X', long)]
     pub show_fail_code: bool,
 
+    /// Store structured log files in DIRECTORY
+    ///
+    /// Log files will be named YYYY-mm-ddTHH:MM:SS-ZZ:ZZ.$command.$pid.log. For
+    /// example, if you were running /bin/ls, the file name might be
+    /// 2023-05-10T20:05:17-07:00.ls.15297.log. The file has a few lines of
+    /// metadata at the top (the exact command line run and the start time) then
+    /// all of the events received and the relative time in fractional seconds.
+    #[clap(short = 'l', long, value_name = "DIRECTORY")]
+    pub log_dir: Option<PathBuf>,
+
     /// Verbosity (may be repeated up to three times)
     #[clap(short, long, action = clap::ArgAction::Count)]
     pub verbose: u8,


### PR DESCRIPTION
This allows the user to specify `--log-dir DIR` which will cause a log file to be created in `DIR`. The log file will be named with the job start date, time, executable file name, and child PID.

The log file will contain the full command line and the start time at the top followed by a blank line then a record of the events received, e.g. output on stdout or stderr, along with the relative time since the process started.

Example:

```text
Command: ["my-script.sh", "arg1", "arg2"]
Start: 2023-05-15T18:31:41.509380000-07:00

+0.000 out foo bar hey
           next line whatever
+0.010 err NOTICE bar hey
+0.100 out mixed
+0.200 \ out .
+0.340 \ out .
+0.610 \ out  done
+0.610 exit 0
```

This also updates the MSRV to 1.65 to support time crate.