### PR TITLE
clean up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,9 +114,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+checksum = "a246e68bb43f6cd9db24bea052a53e40405417c5fb372e3d1a8a7f770a564ef5"
 dependencies = [
  "memchr",
  "once_cell",
@@ -138,9 +138,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
@@ -162,9 +162,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -331,9 +331,9 @@ checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "log"
@@ -441,9 +441,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
 dependencies = [
  "unicode-ident",
 ]
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+checksum = "d1a59b5d8e97dee33696bf13c5ba8ab85341c002922fba050069326b9c498974"
 dependencies = [
  "regex-syntax",
 ]
@@ -483,9 +483,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rust_decimal"

--- a/src/job_logger.rs
+++ b/src/job_logger.rs
@@ -178,6 +178,20 @@ impl JobLogger {
         }
     }
 
+    /// Private: write standard header to log file.
+    fn write_file_header(&mut self) -> anyhow::Result<()> {
+        if let Some(command) = &self.command {
+            let full_command = command.command_line().collect::<Vec<_>>();
+            self.write_metadata(
+                "Command",
+                format!("{:?}", full_command).as_bytes(),
+            )?;
+        }
+
+        let start = self.start_time.format(&Iso8601::DEFAULT)?;
+        self.write_metadata("Start", start.as_bytes())
+    }
+
     /// Private: write a record in the log file.
     fn write_record(&mut self, kind: &str, value: &[u8]) -> anyhow::Result<()> {
         if !self.finished_metadata {
@@ -274,20 +288,6 @@ impl JobLogger {
         }
 
         Ok(())
-    }
-
-    /// Private: write standard header to log file.
-    fn write_file_header(&mut self) -> anyhow::Result<()> {
-        if let Some(command) = &self.command {
-            let full_command = command.command_line().collect::<Vec<_>>();
-            self.write_metadata(
-                "Command",
-                format!("{:?}", full_command).as_bytes(),
-            )?;
-        }
-
-        let start = self.start_time.format(&Iso8601::DEFAULT)?;
-        self.write_metadata("Start", start.as_bytes())
     }
 
     /// Private: create a log file in a given directory.

--- a/src/job_logger.rs
+++ b/src/job_logger.rs
@@ -521,7 +521,7 @@ mod tests {
         check!(!output.contains(&0u8));
         check!(
             re.is_match(&output),
-            "output {:?} does not match {re:?}",
+            "output {} does not match {re:?}",
             output.as_bstr()
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,8 +53,7 @@ fn start(params: Params, job_logger: &mut JobLogger) -> anyhow::Result<()> {
     job_logger.set_child(&child);
 
     let out = Rc::new(RefCell::new(PausableWriter::new(io::stdout())));
-    out.borrow_mut()
-        .set_paused(params.pause_output_initially())?;
+    out.borrow_mut().set_paused(params.start_paused())?;
 
     if params.log_stdout {
         job_logger.add_destination(Destination::Stream(out.clone()));

--- a/src/params.rs
+++ b/src/params.rs
@@ -81,7 +81,7 @@ pub(crate) struct Params {
 
 impl Params {
     /// Pause output until a condition is met.
-    pub fn pause_output_initially(&self) -> bool {
+    pub fn start_paused(&self) -> bool {
         self.on_error || self.on_fail
     }
 


### PR DESCRIPTION
- Tests: clearer failures for regex checks.
- Move `write_file_header()` up in file.
- cargo update.
- `params.pause_output_initially()` -> `params.start_paused()`.
