### PR TITLE
Add option (default on) to make stderr red

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,7 @@ dependencies = [
  "bstr",
  "clap",
  "duration-str",
+ "is-terminal",
  "log",
  "nix",
  "popol",
@@ -201,6 +202,7 @@ dependencies = [
  "shell-words",
  "simplelog",
  "tempfile",
+ "termcolor",
  "thiserror",
  "time",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ anyhow = "1.0.44"
 bstr = { version = "1.1.0", default-features = false }
 clap = { version = "4.0.18", features = ["derive"] }
 duration-str = { version = "0.5.0", default-features = false }
+is-terminal = "0.4.7"
 log = "0.4.14"
 popol = "3.0.0"
 shell-words = "1.1.0"
 simplelog = "0.12.0"
+termcolor = "1.1.3"
 thiserror = "1.0.40"
 time = { version = "0.3.21", features = ["local-offset", "formatting"] }
 

--- a/src/pause_writer.rs
+++ b/src/pause_writer.rs
@@ -1,67 +1,52 @@
+use std::fmt;
 use std::io;
 use std::io::Write;
-
-/// Whether a writer is running or paused.
-#[derive(Clone, PartialEq, Eq, Debug)]
-pub enum State {
-    /// The writer is paused. The content is a buffer containing all data
-    /// written while paused.
-    Paused(Vec<u8>),
-
-    /// The writer is running. All writes go directly to the output stream.
-    Running,
-}
-
-impl State {
-    fn paused() -> Self {
-        Self::Paused(Vec::new())
-    }
-}
-
-impl Default for State {
-    fn default() -> Self {
-        Self::paused()
-    }
-}
+use termcolor::{
+    Buffer, BufferWriter, ColorChoice, StandardStream, WriteColor,
+};
 
 /// Object to either buffer or write output from a job.
-#[derive(Debug)]
-pub struct PausableWriter<W: io::Write> {
-    state: State,
-    writer: W,
+pub struct PausableWriter {
+    paused: bool,
+    writer: StandardStream,
+    buffer_writer: BufferWriter,
+    buffer: Buffer,
 }
 
-impl<W: io::Write> PausableWriter<W> {
-    /// Create a new paused `PausableWriter`
-    pub fn new(writer: W) -> Self {
+impl PausableWriter {
+    /// Create a new paused `PausableWriter` for stdout
+    pub fn stdout(color_choice: ColorChoice) -> Self {
+        let buffer_writer = BufferWriter::stdout(color_choice);
+        let buffer = buffer_writer.buffer();
         Self {
-            state: State::paused(),
-            writer,
+            paused: true,
+            writer: StandardStream::stdout(color_choice),
+            buffer_writer,
+            buffer,
         }
     }
 
     /// Whether or not this is paused
     pub fn is_paused(&self) -> bool {
-        self.state != State::Running
+        self.paused
     }
 
     /// Unpause the writer: write any buffered data and allow future writes to
     /// pass through.
     pub fn unpause(&mut self) -> io::Result<()> {
-        if let State::Paused(buffer) = &self.state {
-            self.writer.write_all(buffer)?;
-            self.writer.flush()?;
+        if self.paused {
+            self.buffer_writer.print(&self.buffer)?;
+            self.buffer.clear();
+            self.writer.flush()?; // FIXME? does this make sense?
         }
 
-        self.state = State::Running;
+        self.paused = false;
         Ok(())
     }
 
     /// Pause the writer: buffer future writes until unpaused.
     pub fn pause(&mut self) {
-        if self.state == State::Running {
-            self.state = State::paused();
-        }
+        self.paused = true;
     }
 
     /// Either pause or unpause the writer based on the parameter.
@@ -75,25 +60,62 @@ impl<W: io::Write> PausableWriter<W> {
     }
 }
 
-impl<W: io::Write> Write for PausableWriter<W> {
+impl fmt::Debug for PausableWriter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PausableWriter")
+            .field("paused", &self.paused)
+            .finish()
+    }
+}
+
+impl Write for PausableWriter {
     fn write(&mut self, input: &[u8]) -> io::Result<usize> {
-        match &mut self.state {
-            State::Running => self.writer.write(input),
-            State::Paused(ref mut buffer) => {
-                buffer.extend_from_slice(input);
-                Ok(input.len())
-            }
+        if self.paused {
+            self.buffer.write(input)
+        } else {
+            self.writer.write(input)
         }
     }
 
-    /// Flush to writer if running
-    ///
-    /// If the writer is paused, this has no effect.
     fn flush(&mut self) -> io::Result<()> {
-        if self.state == State::Running {
-            self.writer.flush()
+        if self.paused {
+            self.buffer.flush()
         } else {
-            Ok(())
+            self.writer.flush()
+        }
+    }
+}
+
+impl WriteColor for PausableWriter {
+    fn supports_color(&self) -> bool {
+        if self.paused {
+            self.buffer.supports_color()
+        } else {
+            self.writer.supports_color()
+        }
+    }
+
+    fn set_color(&mut self, spec: &termcolor::ColorSpec) -> io::Result<()> {
+        if self.paused {
+            self.buffer.set_color(spec)
+        } else {
+            self.writer.set_color(spec)
+        }
+    }
+
+    fn reset(&mut self) -> io::Result<()> {
+        if self.paused {
+            self.buffer.reset()
+        } else {
+            self.writer.reset()
+        }
+    }
+
+    fn is_synchronous(&self) -> bool {
+        if self.paused {
+            self.buffer.is_synchronous()
+        } else {
+            self.writer.is_synchronous()
         }
     }
 }

--- a/tests/fixtures/mixed_output.sh
+++ b/tests/fixtures/mixed_output.sh
@@ -7,3 +7,6 @@ sleep 0.1
 echo 333
 sleep 0.1
 echo bbb >&2
+
+# Exit with the first value passed or 0.
+exit ${1:-0}

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -93,6 +93,35 @@ fn mixed_output_on_error() {
 }
 
 #[test]
+fn mixed_output_unconditional_color() {
+    let output =
+        helpers::run(["--color", "always", "tests/fixtures/mixed_output.sh"])
+            .output()
+            .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111\x1b[0m\x1b[38;5;9maaa\x1b[0m333\n\x1b[0m\x1b[38;5;9mbbb\n\x1b[0m");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
+fn mixed_output_on_fail_color() {
+    let output = helpers::run([
+        "--color",
+        "always",
+        "--on-fail",
+        "tests/fixtures/mixed_output.sh",
+        "1",
+    ])
+    .output()
+    .unwrap();
+
+    check!(output.status.code() == Some(1));
+    check!(output.stdout.as_bstr() == "111\x1b[0m\x1b[38;5;9maaa\x1b[0m333\n\x1b[0m\x1b[38;5;9mbbb\n\x1b[0m");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
 fn invalid_utf8() {
     let output = helpers::run(["tests/fixtures/invalid_utf8.sh"])
         .output()


### PR DESCRIPTION
By default, this only works in terminals, so it’s not useful when running as a cron job wrapper.

This doesn’t presently work on structured log output to a terminal.

Unfortunately, the simplest way to get cross-platform color support is to make `PausableWriter` work only with `termcolor`.