### PR TITLE
more clippy lints

### DIFF
--- a/src/job_logger.rs
+++ b/src/job_logger.rs
@@ -661,7 +661,7 @@ mod tests {
         check!(!output.contains(&0u8));
         check!(
             re.is_match(&output),
-            "output {} does not match {re:?}",
+            r#"output "{}" does not match "{re:?}""#,
             output.as_bstr()
         );
     }

--- a/src/job_logger.rs
+++ b/src/job_logger.rs
@@ -64,6 +64,7 @@ impl Default for JobLogger {
 
 impl JobLogger {
     /// Create a new job logger that will silently discard all logs.
+    #[must_use]
     pub fn none() -> Self {
         JobLogger {
             destinations: vec![],
@@ -99,6 +100,12 @@ impl JobLogger {
     /// This is called on every write, but does nothing after the first call. It
     /// creates log files for all [`Destination::Directory`]s, and writes the
     /// metadata header.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t create a log file, e.g. if there
+    /// is a [`Destination::Directory`], or if it can’t write the log metadata
+    /// header to all destinations.
     pub fn initialize(&mut self) -> anyhow::Result<()> {
         if self.initialized {
             return Ok(());
@@ -110,7 +117,7 @@ impl JobLogger {
         let mut todo = Vec::new();
         for (i, destination) in self.destinations.iter().enumerate() {
             if let Destination::Directory(path) = destination {
-                todo.push((i, path.to_owned()));
+                todo.push((i, path.clone()));
             }
         }
 
@@ -130,6 +137,7 @@ impl JobLogger {
     /// the file has been created. If the logger was created by
     /// [`Self::new_in_directory()`] but nothing has been logged, then the file
     /// will not have been created and this will return an empty `Vec`.
+    #[must_use]
     pub fn paths(&self) -> Vec<&PathBuf> {
         self.destinations
             .iter()
@@ -154,6 +162,10 @@ impl JobLogger {
     }
 
     /// Log an error originating in cron-wrapper, not an [`Event::Error`].
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log.
     pub fn log_wrapper_error(
         &mut self,
         error: &anyhow::Error,
@@ -162,6 +174,10 @@ impl JobLogger {
     }
 
     /// Log an [`Event`] received from the [`Child`].
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log.
     pub fn log_event(&mut self, event: &Event) -> anyhow::Result<()> {
         match &event {
             Event::Stdout(output) => self.write_record(Kind::Stdout, output),
@@ -180,12 +196,16 @@ impl JobLogger {
     }
 
     /// Private: write standard header to log file.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log.
     fn write_file_header(&mut self) -> anyhow::Result<()> {
         if let Some(command) = &self.command {
             let full_command = command.command_line().collect::<Vec<_>>();
             self.write_metadata(
                 "Command",
-                format!("{:?}", full_command).as_bytes(),
+                format!("{full_command:?}").as_bytes(),
             )?;
         }
 
@@ -194,6 +214,10 @@ impl JobLogger {
     }
 
     /// Private: write a record in the log file.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log.
     fn write_record(&mut self, kind: Kind, value: &[u8]) -> anyhow::Result<()> {
         if !self.finished_metadata {
             self.write_all(b"\n")?;
@@ -221,15 +245,20 @@ impl JobLogger {
     }
 
     /// Private: write a metadata line to the top of the log file.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log.
     fn write_metadata(
         &mut self,
         key: &str,
         value: &[u8],
     ) -> anyhow::Result<()> {
-        if self.finished_metadata {
-            // FIXME? Should this be an error?
-            panic!("Tried to write metadata after a record.");
-        }
+        // FIXME? Should this be an error?
+        assert!(
+            !self.finished_metadata,
+            "Tried to write metadata after a record."
+        );
 
         let mut buffer = Vec::with_capacity(key.len() + 2 + value.len() + 1);
         buffer.extend_from_slice(key.as_bytes());
@@ -244,61 +273,33 @@ impl JobLogger {
     /// Private: write value for metadata or record including trailing newline.
     ///
     /// Returns `Ok(true)` if the input ended with a newline.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log.
     fn write_value(
         &mut self,
         input: &[u8],
         indent: usize,
     ) -> anyhow::Result<bool> {
         let mut output: Vec<u8> = Vec::with_capacity(input.len());
-        let newline = self.escape_into(input, indent, &mut output);
+        let newline = escape_into(input, indent, &mut output);
 
         self.write_all(&output)?;
 
         Ok(newline)
     }
 
-    /// Private: escape value for metadata or record in the output buffer.
-    ///
-    /// Always ends output with a newline. Returns true if the input ended with
-    /// a newline.
-    fn escape_into(
-        &self,
-        input: &[u8],
-        indent: usize,
-        output: &mut Vec<u8>,
-    ) -> bool {
-        let indent: Vec<u8> = iter::repeat(b' ').take(indent).collect();
-
-        if let Some((&last, inpu)) = input.split_last() {
-            for &b in inpu {
-                output.push(b);
-                if b == b'\n' {
-                    output.extend_from_slice(&indent);
-                }
-            }
-
-            output.push(last);
-
-            // FIXME? CR?
-            if last == b'\n' {
-                // Ends with a newline; we don’t need to add our own.
-                return true;
-            }
-        }
-
-        // No trailing newline (input was empty or we checked the last
-        // character), so add our own newline.
-        output.push(b'\n');
-
-        false
-    }
-
     /// Private: write raw data to everything in `self.destinations`.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to one of the destinations.
     fn write_all(&mut self, data: &[u8]) -> anyhow::Result<()> {
         self.initialize()?;
 
         // FIXME? apply to all destinations even if one returns an error?
-        for destination in self.destinations.iter_mut() {
+        for destination in &mut self.destinations {
             destination.write_all(data)?;
         }
 
@@ -306,11 +307,16 @@ impl JobLogger {
     }
 
     /// Private: Set the color of the output if the destination supports it.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t set the color for one of the
+    /// destinations that should support it.
     fn set_color(&mut self, spec: &termcolor::ColorSpec) -> anyhow::Result<()> {
         self.initialize()?;
 
         // FIXME? apply to all destinations even if one returns an error?
-        for destination in self.destinations.iter_mut() {
+        for destination in &mut self.destinations {
             destination.set_color(spec)?;
         }
 
@@ -318,11 +324,16 @@ impl JobLogger {
     }
 
     /// Private: Reset the color of the output if the destination supports it.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t reset the color for one of the
+    /// destinations that should support it.
     fn reset_color(&mut self) -> anyhow::Result<()> {
         self.initialize()?;
 
         // FIXME? apply to all destinations even if one returns an error?
-        for destination in self.destinations.iter_mut() {
+        for destination in &mut self.destinations {
             destination.reset()?;
         }
 
@@ -330,15 +341,23 @@ impl JobLogger {
     }
 
     /// Private: create a log file in a given directory.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t create a log file. It will add a
+    /// number to the log file name (before the “.log” extension) and increase
+    /// the number until it finds an available name, or after 100 tries.
+    ///
+    /// It could also return an error if it fails to format the date and time.
     fn create_file_in_directory(
         &self,
         directory: &Path,
     ) -> anyhow::Result<Destination> {
+        const MAX_ATTEMPTS: usize = 100;
         let base = self.generate_file_name_base()?;
         let mut number = String::new();
         let mut file_name = OsString::with_capacity(base.len() + 4);
         let mut path = PathBuf::new();
-        const MAX_ATTEMPTS: usize = 100;
 
         // The first attempt won‘t have a number in the file name, and each
         // loop preps the number for the next loop. Thus, the last loop will
@@ -370,6 +389,10 @@ impl JobLogger {
     }
 
     /// Private: generate the first part of a file name for a log.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it fails to format the date and time.
     fn generate_file_name_base(&self) -> anyhow::Result<OsString> {
         let mut file_name = OsString::from(
             self.start_time.format(&Iso8601::<FILE_NAME_DATE_FORMAT>)?,
@@ -408,6 +431,11 @@ impl JobLogger {
 }
 
 /// Create a file; fail if it already exists.
+///
+/// # Errors
+///
+/// It will return an error if the file already exists, or if there was some
+/// other reason it could not create the file.
 fn exclusive_create_file(path: &Path) -> io::Result<fs::File> {
     fs::OpenOptions::new()
         .write(true)
@@ -518,6 +546,37 @@ impl WriteColor for Destination {
     }
 }
 
+/// Private: escape value for metadata or record in the output buffer.
+///
+/// Always ends output with a newline. Returns true if the input ended with a
+/// newline.
+fn escape_into(input: &[u8], indent: usize, output: &mut Vec<u8>) -> bool {
+    let indent: Vec<u8> = iter::repeat(b' ').take(indent).collect();
+
+    if let Some((&last, inpu)) = input.split_last() {
+        for &b in inpu {
+            output.push(b);
+            if b == b'\n' {
+                output.extend_from_slice(&indent);
+            }
+        }
+
+        output.push(last);
+
+        // FIXME? CR?
+        if last == b'\n' {
+            // Ends with a newline; we don’t need to add our own.
+            return true;
+        }
+    }
+
+    // No trailing newline (input was empty or we checked the last
+    // character), so add our own newline.
+    output.push(b'\n');
+
+    false
+}
+
 /// Used to keep track of how various event types should be displayed.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Kind {
@@ -530,7 +589,7 @@ enum Kind {
 
 impl Kind {
     /// Serialize to a byte string.
-    fn as_bytes(&self) -> &[u8] {
+    fn as_bytes(self) -> &'static [u8] {
         match self {
             Self::Stdout => b"out",
             Self::Stderr => b"err",
@@ -541,18 +600,23 @@ impl Kind {
     }
 
     /// Is this an output (stdout or stderr)?
-    fn is_output(&self) -> bool {
+    fn is_output(self) -> bool {
         matches!(self, Self::Stdout | Self::Stderr)
     }
 
     /// Is this an error (stderr, error, wrapper-error)?
-    fn is_any_error(&self) -> bool {
+    fn is_any_error(self) -> bool {
         matches!(self, Self::Stderr | Self::Error | Self::WrapperError)
     }
 
     /// Write value.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if it can’t write to the log, or if it can’t
+    /// set or reset the text color on a destination that should support it.
     fn write_value(
-        &self,
+        self,
         logger: &mut JobLogger,
         value: &[u8],
         indent: usize,
@@ -627,7 +691,7 @@ mod tests {
         }
     }
 
-    /// Create an IdleTimeout error event.
+    /// Create an `IdleTimeout` error event.
     fn event_idle_timeout() -> Event<'static> {
         Event::Error(command::Error::IdleTimeout {
             timeout: Timeout::Expired {
@@ -642,7 +706,7 @@ mod tests {
         Event::Exit(ExitStatus::from_raw(code))
     }
 
-    /// Make a JobLogger that outputs to a buffer.
+    /// Make a `JobLogger` that outputs to a buffer.
     fn make_buffer_logger() -> (JobLogger, Rc<RefCell<Vec<u8>>>) {
         let output = Rc::new(RefCell::new(Vec::with_capacity(1024)));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 #![warn(missing_docs)]
 //! Miscellaneous useful modules that support cron-wrapper.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped)]
 #![warn(missing_docs)]
 //! Miscellaneous useful modules that support cron-wrapper.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 #![forbid(unsafe_code)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::let_underscore_untyped)]
 
 use anyhow::{bail, Context};
 use clap::Parser;
@@ -21,16 +23,16 @@ mod params;
 use params::Params;
 
 fn main() {
-    if let Err(error) = cli(Params::parse()) {
-        eprintln!("Error: {:#}", error);
+    if let Err(error) = cli(&Params::parse()) {
+        eprintln!("Error: {error:#}");
         process::exit(1);
     }
 }
 
-fn cli(params: Params) -> anyhow::Result<()> {
-    init_logging(&params)?;
+fn cli(params: &Params) -> anyhow::Result<()> {
+    init_logging(params)?;
 
-    let mut job_logger = init_job_logger(&params)?;
+    let mut job_logger = init_job_logger(params)?;
 
     start(params, &mut job_logger).map_err(|error| {
         if let Err(error2) = job_logger.log_wrapper_error(&error) {
@@ -40,7 +42,7 @@ fn cli(params: Params) -> anyhow::Result<()> {
     })
 }
 
-fn start(params: Params, job_logger: &mut JobLogger) -> anyhow::Result<()> {
+fn start(params: &Params, job_logger: &mut JobLogger) -> anyhow::Result<()> {
     let command = Command {
         command: params.command.clone().into(),
         args: params.args.clone(),
@@ -109,7 +111,7 @@ fn start(params: Params, job_logger: &mut JobLogger) -> anyhow::Result<()> {
                 // Don’t return this error since that will cause it to be logged
                 // again as a “wrapper” error.
                 if params.normal_output_enabled() {
-                    eprintln!("Error: {:#}", error);
+                    eprintln!("Error: {error:#}");
                 }
                 process::exit(1);
             }

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use clap::{Parser, ValueEnum};
 use is_terminal::IsTerminal;
 use log::{log_enabled, Level::Trace};
+use std::convert::Into;
 use std::ffi::OsString;
 use std::io;
 use std::path::PathBuf;
@@ -116,7 +117,7 @@ fn parse_duration(input: &str) -> anyhow::Result<Duration> {
         input
             .parse::<u64>()
             .map(Duration::from_secs)
-            .map_err(|e| e.into())
+            .map_err(Into::into)
     } else {
         let duration = duration_str::parse(input)?;
         if duration.subsec_nanos() == duration.subsec_millis() * 1_000_000 {

--- a/src/params.rs
+++ b/src/params.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 #[derive(Debug, Parser)]
 #[clap(version, about)]
+#[allow(clippy::struct_excessive_bools)]
 pub(crate) struct Params {
     /// The executable to run
     pub command: PathBuf,

--- a/src/pause_writer.rs
+++ b/src/pause_writer.rs
@@ -15,6 +15,7 @@ pub struct PausableWriter {
 
 impl PausableWriter {
     /// Create a new paused `PausableWriter` for stdout
+    #[must_use]
     pub fn stdout(color_choice: ColorChoice) -> Self {
         let buffer_writer = BufferWriter::stdout(color_choice);
         let buffer = buffer_writer.buffer();
@@ -33,6 +34,10 @@ impl PausableWriter {
 
     /// Unpause the writer: write any buffered data and allow future writes to
     /// pass through.
+    ///
+    /// # Errors
+    ///
+    /// This may return errors from writing or flushing the writer.
     pub fn unpause(&mut self) -> io::Result<()> {
         if self.paused {
             self.buffer_writer.print(&self.buffer)?;
@@ -50,6 +55,11 @@ impl PausableWriter {
     }
 
     /// Either pause or unpause the writer based on the parameter.
+    ///
+    /// # Errors
+    ///
+    /// This may return errors from writing or flushing the writer when setting
+    /// to unpaused (`set_paused(false)`).
     pub fn set_paused(&mut self, paused: bool) -> io::Result<()> {
         if paused {
             self.pause();

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -61,7 +61,8 @@ pub enum Timeout {
 impl Timeout {
     /// Get the remaining timeout if available.
     ///
-    /// Returns Some(Duration::ZERO) if the timeout has already expired.
+    /// Returns `Some(Duration::ZERO)` if the timeout has already expired.
+    #[must_use]
     pub fn timeout(&self) -> Option<Duration> {
         match &self {
             Self::Never => None,
@@ -77,6 +78,7 @@ impl Timeout {
     ///
     /// If the timeout is `Never`, `Pending`, or `Expired`, then it returns a
     /// clone of `self`.
+    #[must_use]
     pub fn start(&self) -> Self {
         if let Self::Future { timeout } = self {
             Self::Pending {
@@ -93,6 +95,7 @@ impl Timeout {
     /// Returns:
     ///   * `None` if the timeout has not expired.
     ///   * `Some(Timeout::Expired { .. })` if the timeout has expired.
+    #[must_use]
     pub fn check_expired(&self) -> Option<Self> {
         match &self {
             Self::Pending { timeout, start } => {
@@ -119,10 +122,10 @@ impl Timeout {
     ///
     /// This will not do anything special if called on a [`Timeout::Pending`]
     /// that has expired. See [`Timeout::check_expired()`].
+    #[must_use]
     pub fn elapsed(&self) -> Duration {
         match &self {
-            Self::Never => Duration::ZERO,
-            Self::Future { .. } => Duration::ZERO,
+            Self::Never | Self::Future { .. } => Duration::ZERO,
             Self::Pending { start, .. } => start.elapsed(),
             Self::Expired { actual, .. } => *actual,
         }
@@ -136,6 +139,7 @@ impl Timeout {
     ///
     /// This will not do anything special if called on a [`Timeout::Pending`]
     /// that has expired. See [`Timeout::check_expired()`].
+    #[must_use]
     pub fn elapsed_rounded(&self) -> Duration {
         // FIXME: actually consult resolution?
         let elapsed = self.elapsed();


### PR DESCRIPTION
- Make regex check failures clearer in tests.
- Forbid unsafe code in library code.
- Clippy: fix most pedantic lints.
- Clippy: use enum to track state in `JobLogger`
