### PR TITLE
Expand linting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,47 @@
-#![forbid(unsafe_code)]
-#![warn(clippy::pedantic)]
-#![allow(clippy::let_underscore_untyped, clippy::map_unwrap_or)]
-#![warn(missing_docs)]
-
 //! Miscellaneous useful modules that support cron-wrapper.
+
+#![forbid(unsafe_code)]
+#![warn(clippy::nursery, clippy::pedantic)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions
+)]
+// Require docs on everything
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+// Other restriction lints
+#![warn(
+    clippy::arithmetic_side_effects,
+    clippy::as_underscore,
+    clippy::assertions_on_result_states, // see if it makes sense
+    clippy::dbg_macro,
+    clippy::default_union_representation,
+    clippy::empty_structs_with_brackets,
+    clippy::filetype_is_file, // maybe?
+    clippy::fn_to_numeric_cast_any,
+    clippy::format_push_string, // maybe? alternative is fallible.
+    clippy::get_unwrap,
+    clippy::impl_trait_in_params,
+    clippy::integer_division,
+    clippy::lossy_float_literal,
+    clippy::mem_forget,
+    clippy::mixed_read_write_in_expression,
+    clippy::multiple_inherent_impl,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::mutex_atomic,
+    clippy::rc_buffer,
+    clippy::rc_mutex,
+    clippy::same_name_method,
+    clippy::semicolon_inside_block,
+    clippy::str_to_string, // maybe?
+    clippy::string_to_string,
+    clippy::undocumented_unsafe_blocks,
+    clippy::unnecessary_safety_doc,
+    clippy::unnecessary_self_imports,
+    clippy::unneeded_field_pattern,
+    clippy::verbose_file_reads
+)]
 
 /// Read output from child process as events.
 pub mod command;

--- a/src/pause_writer.rs
+++ b/src/pause_writer.rs
@@ -7,9 +7,17 @@ use termcolor::{
 
 /// Object to either buffer or write output from a job.
 pub struct PausableWriter {
+    /// Whether or not we are currently paused.
     paused: bool,
+
+    /// What to write to when unpaused.
     writer: StandardStream,
+
+    /// The writer that writes to `buffer`. Needed because we use [`termcolor`]
+    /// rather than just writing to a normal `Vec<u8>` buffer.
     buffer_writer: BufferWriter,
+
+    /// The buffer to fill while we are paused.
     buffer: Buffer,
 }
 
@@ -28,7 +36,7 @@ impl PausableWriter {
     }
 
     /// Whether or not this is paused
-    pub fn is_paused(&self) -> bool {
+    pub const fn is_paused(&self) -> bool {
         self.paused
     }
 

--- a/tests/exit.rs
+++ b/tests/exit.rs
@@ -1,3 +1,46 @@
+#![forbid(unsafe_code)]
+#![warn(clippy::nursery, clippy::pedantic)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions
+)]
+// Require docs on everything
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+// Other restriction lints
+#![warn(
+    clippy::arithmetic_side_effects,
+    clippy::as_underscore,
+    clippy::assertions_on_result_states, // see if it makes sense
+    clippy::dbg_macro,
+    clippy::default_union_representation,
+    clippy::empty_structs_with_brackets,
+    clippy::filetype_is_file, // maybe?
+    clippy::fn_to_numeric_cast_any,
+    clippy::format_push_string, // maybe? alternative is fallible.
+    clippy::get_unwrap,
+    clippy::impl_trait_in_params,
+    clippy::integer_division,
+    clippy::lossy_float_literal,
+    clippy::mem_forget,
+    clippy::mixed_read_write_in_expression,
+    clippy::multiple_inherent_impl,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::mutex_atomic,
+    clippy::rc_buffer,
+    clippy::rc_mutex,
+    clippy::same_name_method,
+    clippy::semicolon_inside_block,
+    clippy::str_to_string, // maybe?
+    clippy::string_to_string,
+    clippy::undocumented_unsafe_blocks,
+    clippy::unnecessary_safety_doc,
+    clippy::unnecessary_self_imports,
+    clippy::unneeded_field_pattern,
+    clippy::verbose_file_reads
+)]
+
 //! Test handling of child processes exiting various ways.
 use assert2::check;
 use bstr::ByteSlice;

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,3 +1,46 @@
+#![forbid(unsafe_code)]
+#![warn(clippy::nursery, clippy::pedantic)]
+#![allow(
+    clippy::let_underscore_untyped,
+    clippy::manual_string_new,
+    clippy::map_unwrap_or,
+    clippy::module_name_repetitions
+)]
+// Require docs on everything
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+// Other restriction lints
+#![warn(
+    clippy::arithmetic_side_effects,
+    clippy::as_underscore,
+    clippy::assertions_on_result_states, // see if it makes sense
+    clippy::dbg_macro,
+    clippy::default_union_representation,
+    clippy::empty_structs_with_brackets,
+    clippy::filetype_is_file, // maybe?
+    clippy::fn_to_numeric_cast_any,
+    clippy::format_push_string, // maybe? alternative is fallible.
+    clippy::get_unwrap,
+    clippy::impl_trait_in_params,
+    clippy::integer_division,
+    clippy::lossy_float_literal,
+    clippy::mem_forget,
+    clippy::mixed_read_write_in_expression,
+    clippy::multiple_inherent_impl,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::mutex_atomic,
+    clippy::rc_buffer,
+    clippy::rc_mutex,
+    clippy::same_name_method,
+    clippy::semicolon_inside_block,
+    clippy::str_to_string, // maybe?
+    clippy::string_to_string,
+    clippy::undocumented_unsafe_blocks,
+    clippy::unnecessary_safety_doc,
+    clippy::unnecessary_self_imports,
+    clippy::unneeded_field_pattern,
+    clippy::verbose_file_reads
+)]
+
 use assert2::check;
 use bstr::{ByteSlice, B};
 


### PR DESCRIPTION
This enables `clippy::nursery` and a bunch of lints from `clippy::restriction`, and fixes all violations. It adjusts lints to match what I’m working on in other projects.

This is probably not the final lint list — there are comments on the lint list reflecting that I’m unsure about some of the lints.