### PR TITLE
Clarify `Debug` output for `PausableWriter`

### DIFF
--- a/src/pause_writer.rs
+++ b/src/pause_writer.rs
@@ -82,7 +82,7 @@ impl fmt::Debug for PausableWriter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PausableWriter")
             .field("paused", &self.paused)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 


### PR DESCRIPTION
There are three fields in `PausableWriter` that do not support `fmt::Debug`. This switches the `Debug` output to indicate that there are missing fields.