### PR TITLE
Honor timeouts after child has closed stdout/err

### DIFF
--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -168,6 +168,14 @@ impl Timeout {
 
         Duration::new(elapsed.as_secs(), rounded)
     }
+
+    /// Will this never time out?
+    ///
+    /// Returns `true` for [`Timeout::Never`] and `false` for everything else.
+    #[must_use]
+    pub const fn is_never(&self) -> bool {
+        matches!(self, Self::Never)
+    }
 }
 
 impl fmt::Display for Timeout {


### PR DESCRIPTION
Previously we used the standard `wait()` function once the output streams were closed to wait for the child to exit. Unfortunately, this does not allow for a time out.

This is particularly a problem if the child process closes `stdout` and `stderr` then does more work.

This adds a custom `wait()` method to our `Child` struct that honors timeouts by calling `try_wait()` in a busy loop. It might be better to use an alarm signal to wake process within `wait()`, but that could cause problems with other code that uses signals, or if the process has multiple threads.

Fixes: #44 — If child process closes stdout/stderr the timeout will no longer work