### PR TITLE
`job_logger::parser` and `replay` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ dependencies = [
  "is-terminal",
  "log",
  "nix",
+ "nom",
  "popol",
  "regex",
  "shell-words",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ duration-str = { version = "0.5.0", default-features = false }
 is-terminal = "0.4.7"
 log = "0.4.14"
 nix = { version = "0.26.1", default-features = false, features = ["signal", "process"] }
+nom = "7.1.3"
 popol = "3.0.0"
 shell-words = "1.1.0"
 simplelog = "0.12.0"

--- a/examples/replay.rs
+++ b/examples/replay.rs
@@ -1,0 +1,243 @@
+//! `replay` executable.
+
+// Most lint configuration is in lints.toml, but it doesn’t support forbid.
+#![forbid(unsafe_code)]
+
+use anyhow::{anyhow, bail};
+use bstr::ByteSlice;
+use clap::{Parser, ValueEnum};
+use cron_wrapper::job_logger::parser::parse_log;
+use cron_wrapper::job_logger::Kind;
+use is_terminal::IsTerminal;
+use simplelog::{
+    CombinedLogger, Config, ConfigBuilder, LevelFilter, TermLogger,
+    TerminalMode,
+};
+use std::convert::Into;
+use std::fs;
+use std::io;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process;
+use std::str;
+use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
+
+/// Parameters for `replay`.
+#[derive(Debug, Parser)]
+#[clap(version, about)]
+#[allow(clippy::struct_excessive_bools)]
+struct Params {
+    /// The log file to replay
+    pub log_file: PathBuf,
+
+    /// Whether or not to output in color
+    #[clap(long, default_value = "auto", value_name = "WHEN")]
+    pub color: ColorChoice,
+
+    /// Output metadata before actual output.
+    #[clap(short, long)]
+    pub metadata: bool,
+
+    /// Verbosity (may be repeated up to three times)
+    #[clap(short, long, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+}
+
+impl Params {
+    /// Get stream to use for standard output.
+    pub fn out_stream(&self) -> StandardStream {
+        StandardStream::stdout(self.color_choice(&io::stdout()))
+    }
+
+    /// Get stream to use for errors.
+    pub fn err_stream(&self) -> StandardStream {
+        StandardStream::stderr(self.color_choice(&io::stderr()))
+    }
+
+    /// Whether or not to output on a stream in color.
+    ///
+    /// Checks if passed stream is a terminal.
+    pub fn color_choice<T: IsTerminal>(
+        &self,
+        stream: &T,
+    ) -> termcolor::ColorChoice {
+        if self.color == ColorChoice::Auto && !stream.is_terminal() {
+            termcolor::ColorChoice::Never
+        } else {
+            self.color.into()
+        }
+    }
+}
+
+/// Whether or not to output in color
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum ColorChoice {
+    /// Output in color when running in a terminal that supports it
+    Auto,
+
+    /// Always output in color
+    Always,
+
+    /// Never output in color
+    Never,
+}
+
+impl Default for ColorChoice {
+    fn default() -> Self {
+        Self::Auto
+    }
+}
+
+impl From<ColorChoice> for termcolor::ColorChoice {
+    fn from(choice: ColorChoice) -> Self {
+        match choice {
+            ColorChoice::Auto => Self::Auto,
+            ColorChoice::Always => Self::Always,
+            ColorChoice::Never => Self::Never,
+        }
+    }
+}
+
+/// Wrapper to handle errors.
+///
+/// See [`cli()`].
+fn main() {
+    let params = Params::parse();
+    process::exit(cli(&params).unwrap_or_else(|error| {
+        let mut err = params.err_stream();
+        err.set_color(&error_color()).unwrap();
+        writeln!(err, "Error: {error:#}").unwrap();
+        err.reset().unwrap();
+        1
+    }))
+}
+
+/// Do the actual work.
+///
+/// # Errors
+///
+/// This tries to log errors encountered after logging is started, and returns
+/// all errors to [`main()`] to be outputted nicely.
+fn cli(params: &Params) -> anyhow::Result<i32> {
+    init_logging(params)?;
+
+    let mut out = params.out_stream();
+    let mut err = params.err_stream();
+    let err_color = error_color();
+
+    let log_file = fs::read(&params.log_file)?;
+    let (metadata, records) = parse_log(&log_file).map_err(collapse_error)?;
+
+    if params.metadata {
+        for (key, value) in metadata {
+            writeln!(out, "{}: {:?}", key.as_bstr(), value.as_bstr())?;
+        }
+        writeln!(out)?;
+    }
+
+    let mut exit_code: Option<i32> = None;
+
+    for record in records {
+        match record.kind {
+            Kind::Stdout => {
+                out.write_all(&record.value)?;
+                out.flush()?;
+            }
+            Kind::Stderr => {
+                err.set_color(&err_color)?;
+                err.write_all(&record.value)?;
+                err.reset()?;
+                err.flush()?;
+            }
+            Kind::Exit => {
+                // Keep reading so we don’t accidentally hide output if the
+                // logger has some kind of bug.
+                if exit_code.is_some() {
+                    bail!("Multiple exit records found.");
+                }
+                exit_code = Some(str::from_utf8(&record.value)?.parse()?);
+            }
+            Kind::Error => {
+                err.set_color(&err_color)?;
+                err.write_all(b"Error: ")?;
+                err.write_all(&record.value)?;
+                err.reset()?;
+                err.write_all(b"\n")?;
+                err.flush()?;
+            }
+            Kind::WrapperError => {
+                err.set_color(&err_color)?;
+                err.write_all(b"Wrapper error: ")?;
+                err.write_all(&record.value)?;
+                err.reset()?;
+                err.write_all(b"\n")?;
+                err.flush()?;
+            }
+        }
+    }
+
+    Ok(exit_code.unwrap_or(0))
+}
+
+/// Initialize standard logging.
+fn init_logging(params: &Params) -> anyhow::Result<()> {
+    let filter = match params.verbose {
+        4.. => bail!("-v is only allowed up to 3 times."),
+        3 => LevelFilter::Trace,
+        2 => LevelFilter::Debug,
+        1 => LevelFilter::Info,
+        0 => LevelFilter::Warn,
+    };
+
+    // Configure different logging for a module (sqlx::query here).
+    CombinedLogger::init(vec![
+        // Default logger
+        new_term_logger(filter, new_logger_config().build()),
+    ])
+    .unwrap();
+
+    Ok(())
+}
+
+/// Convenience function to make creating [`TermLogger`]s clearer.
+#[allow(clippy::unnecessary_box_returns)] // Using `Box` isn’t our decision.
+fn new_term_logger(level: LevelFilter, config: Config) -> Box<TermLogger> {
+    TermLogger::new(
+        level,
+        config,
+        TerminalMode::Mixed,
+        simplelog::ColorChoice::Auto,
+    )
+}
+
+/// Convenience function to make creating [`ConfigBuilder`]s clearer.
+fn new_logger_config() -> ConfigBuilder {
+    let mut builder = ConfigBuilder::new();
+    builder.set_target_level(LevelFilter::Error);
+
+    // FIXME: If this fails it will just print the time in UTC. That might be a
+    // little surprising, so this should probably warn the user... except that
+    // we haven’t finished setting up logging.
+    let _ = builder.set_time_offset_to_local();
+
+    builder
+}
+
+/// Returns color used to output errors.
+fn error_color() -> ColorSpec {
+    let mut color = ColorSpec::new();
+    color.set_fg(Some(Color::Red));
+    color.set_intense(true);
+    color
+}
+
+/// Collapse a nom error into something that does not borrow the input.
+fn collapse_error(error: nom::Err<nom::error::Error<&[u8]>>) -> anyhow::Error {
+    match error {
+        nom::Err::Incomplete(_) => anyhow!("unexpected EOF"),
+        nom::Err::Error(e) | nom::Err::Failure(e) => {
+            // FIXME: This gives terrible errors.
+            anyhow!("Parse error {:?} at {:?}", e.code, e.input.as_bstr())
+        }
+    }
+}

--- a/src/job_logger/logger.rs
+++ b/src/job_logger/logger.rs
@@ -614,6 +614,8 @@ fn escape_value(input: &[u8], indent: usize, expect_newline: bool) -> Vec<u8> {
         escape_byte_into(last, &mut output);
 
         if last == b'\n' {
+            // FIXME: if expect_newline is false, then a trailing newline should
+            // be specially encoded.
             return output;
         }
     }

--- a/src/job_logger/mod.rs
+++ b/src/job_logger/mod.rs
@@ -9,6 +9,7 @@
 //! from the parent process.
 
 mod logger;
+pub mod parser;
 pub use logger::*;
 
 /// The kind of record to be written. This is more low-level than [`Event`], and
@@ -56,4 +57,33 @@ impl Kind {
     pub const fn is_any_error(self) -> bool {
         matches!(self, Self::Stderr | Self::Error | Self::WrapperError)
     }
+
+    /// How are trailing newlines handled?
+    ///
+    /// See [`TrailingNewline`].
+    #[must_use]
+    pub const fn newline_behavior(self) -> TrailingNewline {
+        if self.is_output() {
+            TrailingNewline::Implicit
+        } else {
+            TrailingNewline::Explicit
+        }
+    }
+}
+
+/// How to treat trailing newlines in a value.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TrailingNewline {
+    /// Values have an implicit trailing newline; to produce a value without
+    /// a trailing newline you have to end the value with a backslash.
+    ///
+    /// This is only used for output records, i.e. events that have
+    /// [`Kind::Stdout`] and [`Kind::Stderr`].
+    Implicit,
+
+    /// Values don’t have a trailing newline unless one is explicitly included.
+    ///
+    /// This is used for everything except output records, e.g. metadata, error
+    /// records, and exit records.
+    Explicit,
 }

--- a/src/job_logger/parser.rs
+++ b/src/job_logger/parser.rs
@@ -1,0 +1,424 @@
+//! Parse a structured log.
+
+use crate::job_logger::{Kind, TrailingNewline};
+use anyhow::bail;
+use nom::{
+    branch::alt,
+    bytes::complete::{is_a, is_not, tag, take_until},
+    character::complete::{char, digit1},
+    combinator::{
+        all_consuming, consumed, flat_map, map, map_res, opt, recognize,
+    },
+    error::ParseError,
+    multi::{count, many0, separated_list1},
+    sequence::{delimited, pair, preceded, separated_pair, tuple},
+    IResult,
+};
+use std::option::Option;
+use std::time::Duration;
+
+/// A record of an event or wrapper error.
+#[derive(Clone, Debug)]
+pub struct Record {
+    /// Time elapsed between start of job and recording the record.
+    pub time_offset: Duration,
+
+    /// What kind of record this is. See [`Kind`].
+    pub kind: Kind,
+
+    /// The value of the record.
+    pub value: Vec<u8>,
+}
+
+/// Parse a complete structured log as a big byte string.
+///
+/// # Errors
+///
+/// This will return an error when there is a parsing problem.
+///
+/// # Panics
+///
+/// This can panic if it gets into what should be an impossible situation.
+///
+/// For example, it uses a parser that generates an error if it doesn’t consume
+/// all of its input. If it finds the parser returned successfully and did not
+/// consume all its input, it will panic.
+#[allow(clippy::type_complexity)] // Hard to avoid.
+pub fn parse_log(
+    input: &[u8],
+) -> Result<
+    (Vec<(&[u8], Vec<u8>)>, Vec<Record>),
+    nom::Err<nom::error::Error<&[u8]>>,
+> {
+    let mut parser = all_consuming(pair(
+        metadata_section_parser(),
+        map(
+            opt(preceded(tag("\n"), many0(record_parser()))),
+            Option::unwrap_or_default,
+        ),
+    ));
+
+    let (rest, (metadata, records)) = parser(input)?;
+    assert!(
+        rest.is_empty(),
+        "Should be impossible: all_consuming() returned trailing data."
+    );
+
+    Ok((metadata, records))
+}
+
+/// Generate a parser for the metadata section of a structured log.
+pub fn metadata_section_parser<'a, E>(
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Vec<(&[u8], Vec<u8>)>, E>
+where
+    E: ParseError<&'a [u8]>
+        + nom::error::FromExternalError<&'a [u8], anyhow::Error>,
+{
+    many0(separated_pair(
+        is_not("\n\r \t:#"),
+        tag(": "),
+        // The indent for metadata is always 4 characters.
+        value_parser(4, TrailingNewline::Explicit),
+    ))
+}
+
+/// Generate a parser for an event record in a structured log.
+pub fn record_parser<'a, E>(
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Record, E>
+where
+    E: ParseError<&'a [u8]>
+        + nom::error::FromExternalError<&'a [u8], anyhow::Error>,
+{
+    let kind_parser = delimited(
+        is_a(" "),
+        alt((
+            map(tag("out"), |_| Kind::Stdout),
+            map(tag("err"), |_| Kind::Stderr),
+            map(tag("exit"), |_| Kind::Exit),
+            map(tag("ERROR"), |_| Kind::Error),
+            map(tag("WRAPPER-ERROR"), |_| Kind::WrapperError),
+        )),
+        char(' '),
+    );
+
+    flat_map(
+        // Parse "1.123 out " and note the number of bytes captured, then...
+        consumed(tuple((seconds_parser(), kind_parser))),
+        // ...parse the remainder of the record (possibly multiple lines) now
+        // that we know how long the indent should be.
+        |(prefix, (time_offset, kind))| {
+            map(
+                // The indent should match the length of the prefix.
+                value_parser(prefix.len(), kind.newline_behavior()),
+                move |value| Record {
+                    time_offset,
+                    kind,
+                    value,
+                },
+            )
+        },
+    )
+}
+
+/// Generate a parser for a metadata or record value.
+pub fn value_parser<'a, E>(
+    indent: usize,
+    newline: TrailingNewline,
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Vec<u8>, E>
+where
+    E: ParseError<&'a [u8]>
+        + nom::error::FromExternalError<&'a [u8], anyhow::Error>,
+{
+    map(
+        separated_list1(
+            // The indent should match the length of the prefix.
+            count(char(' '), indent),
+            // The rest of the line including the newline character.
+            recognize(pair(take_until("\n"), tag("\n"))),
+        ),
+        move |lines| {
+            let value: Vec<u8> = lines.concat();
+            unescape_value(value.as_slice(), newline)
+        },
+    )
+}
+
+/// Convert escaped value to its original form.
+///
+/// This expects `input` to have a trailing newline.
+fn unescape_value(input: &[u8], newline: TrailingNewline) -> Vec<u8> {
+    /// Get the value of a hex digit [0-9a-f].
+    #[inline]
+    const fn parse_hex(c: u8) -> Option<u8> {
+        // No side effects because the `match` limits the values used in math.
+        #[allow(clippy::arithmetic_side_effects)]
+        match c {
+            b'0'..=b'9' => Some(c - b'0'),
+            b'a'..=b'f' => Some(c - b'a' + 0x0a),
+            _ => None,
+        }
+    }
+
+    /// Match an escape sequence starting with b'\\'.
+    #[inline]
+    fn match_escape(input: &[u8]) -> (Option<u8>, usize) {
+        match input {
+            [b'\\', b'b', ..] => (Some(0x08), 2), // backspace
+            [b'\\', b'r', ..] => (Some(b'\r'), 2),
+            [b'\\', b'\\', ..] => (Some(b'\\'), 2),
+            [b'\\', b'x', h, l, ..] => {
+                if let (Some(h), Some(l)) = (parse_hex(*h), parse_hex(*l)) {
+                    // h and l are within [0x0..=0xf] so this is always safe.
+                    #[allow(clippy::arithmetic_side_effects)]
+                    (Some(0x10 * h + l), 4)
+                } else {
+                    // h and l weren’t both hex digits, so invalid escape.
+                    (Some(b'\\'), 1)
+                }
+            }
+            [b'\\', b'\n', ..] => {
+                // Backslash at the end of the line: don’t append \n.
+                (None, 2)
+            }
+            [b'\\', ..] => (Some(b'\\'), 1), // Invalid escape
+            _ => panic!("input must start with backslash"),
+        }
+    }
+
+    let mut output = Vec::with_capacity(input.len().checked_add(1).unwrap());
+    let mut rest = input;
+    let mut iter = rest.iter();
+    while let Some(i) = iter.position(|&b| b == b'\\') {
+        match match_escape(&rest[i..]) {
+            (Some(b'\\'), 1) => {
+                // Consume b'\\' and expand to b'\\' is a no-op.
+            }
+            (expansion, consumed) => {
+                output.extend_from_slice(&rest[..i]);
+                if let Some(expansion) = expansion {
+                    output.push(expansion);
+                }
+                // `i + consumed` will always be `<= rest.len()`.
+                #[allow(clippy::arithmetic_side_effects)]
+                let j = i + consumed;
+                rest = &rest[j..];
+                iter = rest.iter();
+            }
+        }
+    }
+
+    if newline == TrailingNewline::Explicit && rest.ends_with(&b"\n"[..]) {
+        // Strip the trailing newline.
+        output.extend_from_slice(rest.split_last().unwrap().1);
+    } else {
+        output.extend_from_slice(rest);
+    }
+
+    output
+}
+
+/// # Parse "#.###" as seconds.
+///
+/// The input string may have precision down to nanoseconds, i.e. 9 digits after
+/// the decimal point. More digits will cause an error.
+pub fn seconds_parser<'a, E>(
+) -> impl FnMut(&'a [u8]) -> IResult<&'a [u8], Duration, E>
+where
+    E: ParseError<&'a [u8]>
+        + nom::error::FromExternalError<&'a [u8], anyhow::Error>,
+{
+    map_res(
+        pair(digit1, opt(preceded(tag("."), digit1))),
+        bstr_to_duration,
+    )
+}
+
+/// Take a pair of byte strings `(seconds, fractional_seconds)` and calculate
+/// what that is in nanoseconds.
+///
+/// `fractional_seconds` is the byte string from immediately after the period,
+/// so it could have any precision.
+///
+/// # Errors
+///
+/// Returns an error if the fractional seconds have more than nanosecond
+/// precision, i.e. there are more than 9 digits.
+///
+/// # Panics
+///
+/// Panics if the number being parsed wouldn’t fit in a u64, or if any of the
+/// input bytes aren’t ASCII digits.
+#[allow(clippy::items_after_statements)]
+fn bstr_to_duration(
+    (seconds, fractional_seconds): (&[u8], Option<&[u8]>),
+) -> anyhow::Result<Duration> {
+    // FIXME: This should return an error if the full seconds number would
+    // overflow, rather than panicking.
+
+    /// Allowable number of digits for decimal seconds.
+    const PRECISION: u32 = 9;
+    /// 10^PRECISION. Would use `checked_pow()`, but `expect()` is not `const`.
+    const PRECISION_POW: (u64, bool) = 10u64.overflowing_pow(PRECISION);
+    assert!(!PRECISION_POW.1, "10^PRECISION overflows");
+    /// 10^PRECISION, i.e. the reciprocal of the smallest value expressible.
+    const RECIP_PRECISION: u64 = PRECISION_POW.0;
+
+    let mut offset = bstr_to_u64(seconds)
+        .checked_mul(RECIP_PRECISION)
+        .expect("seconds overflow number parser");
+
+    // If there are decimal seconds, convert them to nanoseconds.
+    if let Some(fractional_seconds) = fractional_seconds {
+        // Get length of decimal seconds as u32.
+        let Ok(fraction_len) = u32::try_from(fractional_seconds.len()) else {
+            bail!("Found time offset with greater than nanosecond precision.");
+        };
+
+        // Figure out precision of provided decimal seconds.
+        let Some(precision) = PRECISION.checked_sub(fraction_len) else {
+            bail!("Found time offset with greater than nanosecond precision.");
+        };
+
+        let precision = 10u64
+            .checked_pow(precision)
+            .expect("10^precision overflows");
+
+        offset = offset
+            .checked_add(
+                bstr_to_u64(fractional_seconds)
+                    .checked_mul(precision)
+                    .expect("overflow increasing precision of decimal seconds"),
+            )
+            .expect("overflow adding decimal seconds to seconds");
+    }
+
+    Ok(Duration::from_nanos(offset))
+}
+
+/// Convert a byte string of ASCII digits to a u64.
+///
+/// # Panics
+///
+/// Panics if the number being parsed wouldn’t fit in a u64, or if any of
+/// the input bytes aren’t ASCII digits.
+fn bstr_to_u64(input: &[u8]) -> u64 {
+    input.iter().fold(0u64, |sum, digit| {
+        let digit = digit.checked_sub(b'0').expect("input not an ASCII digit");
+        assert!(digit < 10, "input not an ASCII digit");
+        sum.checked_mul(10)
+            .expect("number too large")
+            .checked_add(digit.into())
+            .expect("number too large")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // Tests just look complicated to clippy.
+    #![allow(clippy::cognitive_complexity)]
+
+    use super::*;
+    use assert2::{check, let_assert};
+
+    #[test]
+    fn bstr_to_duration_normal() {
+        // Zero and 100ms
+        check!(
+            Duration::ZERO
+                == bstr_to_duration((&b"0"[..], Some(&b"000000"[..]))).unwrap()
+        );
+        check!(
+            Duration::from_millis(100)
+                == bstr_to_duration((&b"0"[..], Some(&b"100"[..]))).unwrap()
+        );
+    }
+
+    #[test]
+    fn bstr_to_duration_milliseconds() {
+        // Down to millisecond precision
+        check!(
+            Duration::from_millis(33_000)
+                == bstr_to_duration((&b"33"[..], None)).unwrap()
+        );
+        check!(
+            Duration::from_millis(33_900)
+                == bstr_to_duration((&b"33"[..], Some(&b"9"[..]))).unwrap()
+        );
+        check!(
+            Duration::from_millis(33_090)
+                == bstr_to_duration((&b"33"[..], Some(&b"09"[..]))).unwrap()
+        );
+        check!(
+            Duration::from_millis(33_009)
+                == bstr_to_duration((&b"33"[..], Some(&b"009"[..]))).unwrap()
+        );
+    }
+
+    #[test]
+    fn bstr_to_duration_nanoseconds() {
+        check!(
+            Duration::from_nanos(1_002_003)
+                == bstr_to_duration((&b"0"[..], Some(&b"001002003"[..])))
+                    .unwrap()
+        );
+
+        let_assert!(
+            Err(_) = bstr_to_duration((&b"0"[..], Some(&b"0010020039"[..])))
+        );
+    }
+
+    /// Helper function to make tests easier to read.
+    fn unescape_value_str(input: &str, newline: TrailingNewline) -> String {
+        String::from_utf8(unescape_value(input.as_bytes(), newline)).unwrap()
+    }
+
+    #[test]
+    fn unescape() {
+        let nl = TrailingNewline::Explicit;
+        check!(unescape_value_str("a\\nb", nl) == "a\\nb");
+        check!(unescape_value_str("a\nb", nl) == "a\nb");
+        check!(unescape_value_str(r"a\bb", nl) == "a\x08b");
+        check!(unescape_value_str(r"a\b\rb", nl) == "a\x08\rb");
+        check!(unescape_value_str(r"\x20", nl) == " ");
+        check!(unescape_value_str(r"\x00", nl) == "\0");
+        check!(unescape_value_str(r"\x0", nl) == "\\x0");
+        check!(unescape_value_str(r"\x0a", nl) == "\x0a");
+        check!(unescape_value_str(r"\x0A", nl) == "\\x0A");
+        check!(unescape_value_str(r"\x0g", nl) == "\\x0g");
+        check!(unescape_value_str(r"\x", nl) == "\\x");
+        check!(unescape_value_str(r"\xA", nl) == "\\xA");
+        check!(unescape_value_str(r"\xA0", nl) == "\\xA0");
+        check!(unescape_value_str("", nl) == "");
+        check!(unescape_value_str("\\", nl) == "\\");
+        check!(unescape_value_str("abc\nxyz", nl) == "abc\nxyz");
+        check!(unescape_value_str("abc\\\nxyz", nl) == "abcxyz");
+        check!(unescape_value_str("abc\\\\\nxyz", nl) == "abc\\\nxyz");
+        check!(unescape_value_str("abc\\\\\\\nxyz", nl) == "abc\\xyz");
+    }
+
+    #[test]
+    fn unescape_line_ending_output() {
+        let nl = TrailingNewline::Implicit;
+        check!(unescape_value_str("abc", nl) == "abc");
+        check!(unescape_value_str("abc\n", nl) == "abc\n");
+        check!(unescape_value_str("abc\\\n", nl) == "abc");
+        check!(unescape_value_str("abc\\\\\n", nl) == "abc\\\n");
+        check!(unescape_value_str("abc\\\\\\\n", nl) == "abc\\");
+    }
+
+    #[test]
+    fn unescape_line_ending_non_output() {
+        let nl = TrailingNewline::Explicit;
+        check!(unescape_value_str("abc", nl) == "abc");
+        check!(unescape_value_str("abc\n", nl) == "abc");
+        check!(unescape_value_str("abc\\\n", nl) == "abc");
+        check!(unescape_value_str("abc\\\\\n", nl) == "abc\\");
+        check!(unescape_value_str("abc\\\\\\\n", nl) == "abc\\");
+    }
+
+    #[test]
+    fn unescape_invalid_utf8() {
+        let nl = TrailingNewline::Explicit;
+        check!(unescape_value(br"\xff", nl) == &b"\xff"[..]);
+    }
+}

--- a/tests/fixtures/invalid_utf8.log
+++ b/tests/fixtures/invalid_utf8.log
@@ -1,0 +1,5 @@
+Command: ["tests/fixtures/invalid_utf8.sh"]
+Start: 2023-07-05T11:07:40.911008000-07:00
+
+0.003 out bad â(¡ bad
+0.003 exit 0

--- a/tests/fixtures/output/invalid_utf8.out
+++ b/tests/fixtures/output/invalid_utf8.out
@@ -1,0 +1,5 @@
+Command: ["tests/fixtures/invalid_utf8.sh"]
+Start: 2023-07-26T13:32:22.288640000-07:00
+
+0.003 out bad â(¡ bad
+0.003 exit 0

--- a/tests/fixtures/output/midline_sleep.out
+++ b/tests/fixtures/output/midline_sleep.out
@@ -1,0 +1,7 @@
+Command: ["tests/fixtures/midline_sleep.sh"]
+Start: 2023-07-26T13:32:22.387293000-07:00
+
+0.003 out 111\
+0.108 out 222\
+0.218 out 333
+0.218 exit 0

--- a/tests/fixtures/output/mixed_output.out
+++ b/tests/fixtures/output/mixed_output.out
@@ -1,0 +1,8 @@
+Command: ["tests/fixtures/mixed_output.sh"]
+Start: 2023-07-26T13:32:22.710025000-07:00
+
+0.003 out 111\
+0.111 err aaa\
+0.219 out 333
+0.327 err bbb
+0.327 exit 0

--- a/tests/fixtures/output/only_out.out
+++ b/tests/fixtures/output/only_out.out
@@ -1,0 +1,5 @@
+Command: ["tests/fixtures/only_out.sh"]
+Start: 2023-07-26T13:32:23.156585000-07:00
+
+0.003 out out
+0.003 exit 0

--- a/tests/fixtures/output/only_out_fail.out
+++ b/tests/fixtures/output/only_out_fail.out
@@ -1,0 +1,5 @@
+Command: ["tests/fixtures/only_out_fail.sh"]
+Start: 2023-07-26T13:32:23.254904000-07:00
+
+0.003 out out
+0.003 exit 1

--- a/tests/fixtures/output/sleep_touch.out
+++ b/tests/fixtures/output/sleep_touch.out
@@ -1,0 +1,4 @@
+Command: ["tests/fixtures/sleep_touch.sh"]
+Start: 2023-07-26T13:32:23.351057000-07:00
+
+0.117 exit 1

--- a/tests/fixtures/output/stdouterr-idle-timeout.out
+++ b/tests/fixtures/output/stdouterr-idle-timeout.out
@@ -1,0 +1,8 @@
+Command: ["tests/fixtures/stdouterr.sh"]
+Start: 2023-07-26T13:32:00.259549000-07:00
+
+0.003 out 01 stdout
+          02 stdout
+0.003 err 03 STDERR
+          04 STDERR sleep 0.1
+0.053 ERROR IdleTimeout { timeout: Expired { requested: 50ms, actual: 50.078023ms } }

--- a/tests/fixtures/output/stdouterr-run-timeout.out
+++ b/tests/fixtures/output/stdouterr-run-timeout.out
@@ -1,0 +1,12 @@
+Command: ["tests/fixtures/stdouterr.sh"]
+Start: 2023-07-26T13:30:52.377328000-07:00
+
+0.004 out 01 stdout
+0.004 out 02 stdout
+0.004 err 03 STDERR
+          04 STDERR sleep 0.1
+0.111 out 05 stdout sleep 0.1
+0.217 out 07 stdout \
+0.217 err 06 STDERR 08 STDERR
+          09 STDERR sleep 0.2 \
+0.301 ERROR RunTimeout { timeout: Expired { requested: 300ms, actual: 300.699222ms } }

--- a/tests/fixtures/output/stdouterr.out
+++ b/tests/fixtures/output/stdouterr.out
@@ -1,0 +1,14 @@
+Command: ["tests/fixtures/stdouterr.sh"]
+Start: 2023-07-26T13:32:23.568083000-07:00
+
+0.003 out 01 stdout
+0.003 out 02 stdout
+0.003 err 03 STDERR
+          04 STDERR sleep 0.1
+0.106 out 05 stdout sleep 0.1
+0.216 out 07 stdout \
+0.216 err 06 STDERR 08 STDERR
+          09 STDERR sleep 0.2 \
+0.422 out 10 stdout sleep 0.1 \
+0.531 err 11 STDERR
+0.531 exit 143

--- a/tests/fixtures/stdouterr.sh.log
+++ b/tests/fixtures/stdouterr.sh.log
@@ -1,0 +1,15 @@
+Command: ["tests/fixtures/stdouterr.sh"]
+Start: 2023-05-29T18:21:35.146758000-07:00
+
+0.004 out 01 stdout
+0.004 out 02 stdout
+0.004 err 03 STDERR
+          04 STDERR sleep 0.1
+0.109 out 05 stdout sleep 0.1
+0.216 err 06 STDERR 
+0.216 \ out 07 stdout 
+0.216 \ err 08 STDERR
+          09 STDERR sleep 0.2 
+0.421 \ out 10 stdout sleep 0.1 
+0.530 \ err 11 STDERR
+0.531 exit 143


### PR DESCRIPTION
This adds a `replay` example that parses structured log files and reproduces the output as if it was just run through `cron-wrapper`. It doesn’t presently parse errors so it prints their `Debug` output.

This is just a starting point, but I think it’s solid enough to merge.

There are no integration tests, and most of the parser is missing unit tests.

This should probably be integrates into the cron-wrapper binary as a subcommand. Possibly it should be available as a symlink, i.e. the behavior should change based on `argv[0]`.

Fixes #32: Add replay command to replay log files