### PR TITLE
Timeout: use `TIMEOUT_RESOLUTION` in rounding

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -107,14 +107,14 @@ pub enum Error {
     },
 
     /// The idle timeout elapsed waiting for input in `poll()`.
-    #[error("Timed out waiting for input after {:?}", timeout.elapsed_rounded())]
+    #[error("Timed out waiting for input after {:?}", timeout.elapsed_rounded_to(Duration::from_millis(1)))]
     IdleTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,
     },
 
     /// The run timeout elapsed.
-    #[error("Run timed out after {:?}", timeout.elapsed_rounded())]
+    #[error("Run timed out after {:?}", timeout.elapsed_rounded_to(Duration::from_millis(1)))]
     RunTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,


### PR DESCRIPTION
Previously, `elapsed_rounded()` always rounded to the nearest millisecond. It still does that, but it bases it on `TIMEOUT_RESOLUTION` instead of hard coding the precision.