### PR TITLE
Add `Timeout::check_expired_within()`

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -767,8 +767,6 @@ impl Child {
                 None => {
                     // FIXME: busy wait. Could use a signal? Could sleep for
                     // longer?
-                    // FIXME: the timeout comparison doesn’t round, so if it’s
-                    // within a 1ms of the timeout it will exit.
                     std::thread::yield_now();
                 }
             }
@@ -799,7 +797,9 @@ impl Child {
         let timeout = original_timeout.start();
 
         while self.events.is_empty() {
-            if let Some(expired) = timeout.check_expired() {
+            if let Some(expired) =
+                timeout.check_expired_within(Duration::from_millis(1))
+            {
                 return Err(timeout_error(original_timeout, expired));
             }
 


### PR DESCRIPTION
`check_expired_within()` allows for checking timeouts when the resolution is larger than 1 nanosecond.

For example, [`poll.2`] takes a timeout measured in milliseconds. If we didn’t take the resolution into account, it we might try to re-run `poll()` despite the timeout having already elapsed from its perspective.

This also changes `Timeout::check_expired()` to operate on a resolution of nanoseconds (the smallest unit of time we can represent with `Duration`) instead of working on milliseconds. To get the previous behavior we have to change `timeout.check_expired()` to `timeout.check_expired_within(Duration::from_millis(1))`.

[`poll.2`]: https://man7.org/linux/man-pages/man2/poll.2.html
