### PR TITLE
`Timeout::elapsed_rounded_to()`

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -120,14 +120,14 @@ pub enum Error {
     },
 
     /// The idle timeout elapsed waiting for input in `poll()`.
-    #[error("Timed out waiting for input after {:?}", timeout.elapsed_rounded())]
+    #[error("Timed out waiting for input after {:?}", timeout.elapsed_rounded_to(Duration::from_millis(1)))]
     IdleTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,
     },
 
     /// The run timeout elapsed.
-    #[error("Run timed out after {:?}", timeout.elapsed_rounded())]
+    #[error("Run timed out after {:?}", timeout.elapsed_rounded_to(Duration::from_millis(1)))]
     RunTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,

--- a/src/command.rs
+++ b/src/command.rs
@@ -11,6 +11,7 @@
 //! writes to stdout and then immediately writes to stderr, it may be too fast
 //! for the reading process to catch.
 
+use crate::roundable::Roundable;
 use crate::timeout::Timeout;
 use bstr::ByteSlice;
 use log::{debug, error, info, trace};
@@ -120,14 +121,14 @@ pub enum Error {
     },
 
     /// The idle timeout elapsed waiting for input in `poll()`.
-    #[error("Timed out waiting for input after {:?}", timeout.elapsed_rounded_to(Duration::from_millis(1)))]
+    #[error("Timed out waiting for input after {:?}", timeout.elapsed().round_to(Duration::from_millis(1)))]
     IdleTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,
     },
 
     /// The run timeout elapsed.
-    #[error("Run timed out after {:?}", timeout.elapsed_rounded_to(Duration::from_millis(1)))]
+    #[error("Run timed out after {:?}", timeout.elapsed().round_to(Duration::from_millis(1)))]
     RunTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,4 +7,5 @@ pub mod command;
 pub mod job_logger;
 pub mod lock;
 pub mod pause_writer;
+pub mod roundable;
 pub mod timeout;

--- a/src/roundable.rs
+++ b/src/roundable.rs
@@ -1,0 +1,192 @@
+//! # Roundable values
+//!
+//! This provides and implementation of rounding for various values, including
+//! [`std::time::Duration`].
+
+use std::time::Duration;
+
+/// Add methods to round to an arbitrary factor.
+///
+/// For example, you might wish to round an integer to the nearest 10s:
+///
+/// ```rust
+/// use cron_wrapper::roundable::Roundable;
+///
+/// assert!(310 == 314.round_to(10));
+/// assert!(300 == 314.round_to(100));
+/// ```
+pub trait Roundable: Sized {
+    /// Round to the nearest `factor`.
+    #[must_use]
+    fn round_to(&self, factor: Self) -> Self {
+        self.try_round_to(factor).expect("overflow while rounding")
+    }
+
+    /// Round to the nearest `factor`.
+    #[must_use]
+    fn try_round_to(&self, factor: Self) -> Option<Self>;
+}
+
+/// Implement rounding for numeric types.
+macro_rules! roundable_num {
+    ($($ty:ident)+) => {
+        $(
+        impl Roundable for $ty {
+            fn try_round_to(&self, factor: Self) -> Option<Self> {
+                // FIXME: make into error
+                assert!(factor > 0, "try_round_to() requires positive factor");
+
+                #[allow(clippy::arithmetic_side_effects)]
+                let remainder = self % factor;
+
+                // remainder <= self
+                #[allow(clippy::arithmetic_side_effects)]
+                let base = self - remainder;
+
+                #[allow(clippy::integer_division)]
+                if remainder < factor / 2 {
+                    Some(base)
+                } else {
+                    base.checked_add(factor)
+                }
+            }
+        }
+        )+
+    }
+}
+
+roundable_num!(i8 i16 i32 i64 i128 isize);
+roundable_num!(u8 u16 u32 u64 u128 usize);
+
+impl Roundable for Duration {
+    fn try_round_to(&self, factor: Self) -> Option<Self> {
+        // Duration will always fit into u128 as nanoseconds.
+        self.as_nanos()
+            .try_round_to(factor.as_nanos())
+            .map(nanos_to_duration)
+    }
+}
+
+/// Create a new [`Duration`] from a `u128` of nanoseconds.
+///
+/// This is essentially just [`Duration::from_nanos()`] but it works on a
+/// `u128`, which can represent any valid `Duration`.
+///
+/// # Panics
+///
+/// `Duration` can only represent 64 bits worth of seconds and less than 32 bits
+/// (1e9) worth of nanoseconds, which works out to being roughly 94 bits. A
+/// `u128` can therefore represent values that are invalid `Duration`s. This
+/// will panic in those cases.
+fn nanos_to_duration(total: u128) -> Duration {
+    /// Just to make things clear.
+    const NANOS_PER_SECOND: u128 = 1_000_000_000;
+    #[allow(clippy::integer_division)]
+    Duration::new(
+        (total / NANOS_PER_SECOND).try_into().expect(
+            "nanos_to_duration() overflowed seconds value for Duration",
+        ),
+        (total % NANOS_PER_SECOND).try_into().unwrap(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert2::check;
+    use std::time::Duration;
+
+    /// Convenient alias for [`Duration::from_millis()`].
+    const fn ms(ms: u64) -> Duration {
+        Duration::from_millis(ms)
+    }
+
+    #[test]
+    fn round_millisecond_to_nearest_millisecond() {
+        check!(ms(10) == ms(10).round_to(ms(1)));
+
+        check!(ms(10) == ms(10).round_to(ms(2)));
+        check!(ms(10) == ms(9).round_to(ms(2)));
+
+        check!(ms(9) == ms(9).round_to(ms(3)));
+        check!(ms(9) == ms(10).round_to(ms(3)));
+        check!(ms(12) == ms(11).round_to(ms(3)));
+        check!(ms(12) == ms(12).round_to(ms(3)));
+    }
+
+    #[test]
+    fn round_second_to_nearest_millisecond() {
+        check!(ms(1_010) == ms(1_010).round_to(ms(1)));
+
+        check!(ms(1_010) == ms(1_010).round_to(ms(2)));
+        check!(ms(1_010) == ms(1_009).round_to(ms(2)));
+
+        check!(ms(1_008) == ms(1_008).round_to(ms(3)));
+        check!(ms(1_008) == ms(1_009).round_to(ms(3)));
+        check!(ms(1_011) == ms(1_010).round_to(ms(3)));
+        check!(ms(1_011) == ms(1_011).round_to(ms(3)));
+    }
+
+    #[test]
+    fn round_second_to_nearest_second() {
+        check!(ms(0) == ms(499).round_to(ms(1_000)));
+        check!(ms(1_000) == ms(500).round_to(ms(1_000)));
+        check!(ms(1_000) == ms(1_010).round_to(ms(1_000)));
+        check!(ms(1_000) == ms(1_499).round_to(ms(1_000)));
+        check!(ms(2_000) == ms(1_500).round_to(ms(1_000)));
+
+        check!(ms(1_001) == ms(1_000).round_to(ms(1_001)));
+        check!(ms(1_001) == ms(1_001).round_to(ms(1_001)));
+        check!(ms(1_001) == ms(1_002).round_to(ms(1_001)));
+    }
+
+    #[test]
+    fn round_to_giant_factor() {
+        check!(ms(0) == ms(1_000_000).round_to(Duration::MAX));
+        check!(Duration::MAX == Duration::MAX.round_to(Duration::MAX));
+    }
+
+    #[test]
+    #[should_panic(expected = "try_round_to() requires positive factor")]
+    fn round_to_zero_factor() {
+        let _ = ms(10).round_to(ms(0));
+    }
+
+    /// Theoretical maximum Duration as nanoseconds (based on u64 for seconds).
+    const NANOS_MAX: u128 = u64::MAX as u128 * 1_000_000_000 + 999_999_999;
+
+    #[test]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn nanos_to_duration_ok() {
+        check!(Duration::ZERO == nanos_to_duration(0));
+        check!(Duration::new(1, 1) == nanos_to_duration(1_000_000_001));
+
+        // Check Duration::MAX two ways, since according it its docs it can vary
+        // based on platform.
+        check!(Duration::MAX == nanos_to_duration(Duration::MAX.as_nanos()));
+        check!(
+            Duration::new(u64::MAX, 999_999_999)
+                == nanos_to_duration(NANOS_MAX)
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
+    )]
+    fn nanos_to_duration_overflow() {
+        nanos_to_duration(Duration::MAX.as_nanos() + 1);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
+    )]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn nanos_to_duration_overflow_manual() {
+        // One over the maximum duration. Just in case `Duration::MAX` is some
+        // other value, since the docs say it can vary by platform even if it
+        // currently is always `u64::MAX * 1_000_000_000 + 999_999_999`.
+        nanos_to_duration(NANOS_MAX + 1);
+    }
+}

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -175,22 +175,6 @@ impl Timeout {
         }
     }
 
-    /// Calculate how much of the timeout has elapsed, rounded to the nearest
-    /// `factor` of time.
-    ///
-    /// For example, if `factor` is `Duration::from_millis(1)`, then it will
-    /// round the elapsed time to the nearest millisecond.
-    ///
-    /// [`Timeout::Never`] and [`Timeout::Future`] both always return
-    /// [`Duration::ZERO`].
-    ///
-    /// This will not do anything special if called on a [`Timeout::Pending`]
-    /// that has expired. See [`Timeout::check_expired()`].
-    #[must_use]
-    pub fn elapsed_rounded_to(&self, factor: Duration) -> Duration {
-        round_duration(self.elapsed(), factor)
-    }
-
     /// Will this never time out?
     ///
     /// Returns `true` for [`Timeout::Never`] and `false` for everything else.
@@ -198,61 +182,6 @@ impl Timeout {
     pub const fn is_never(&self) -> bool {
         matches!(self, Self::Never)
     }
-}
-
-/// Round a `Duration` to the nearest `factor`.
-///
-/// # Panics
-///
-/// Panics if `factor` is 0.
-#[inline]
-fn round_duration(input: Duration, factor: Duration) -> Duration {
-    let nanos = input.as_nanos();
-    let factor = factor.as_nanos();
-
-    assert_ne!(factor, 0, "0 is invalid factor for round_duration()");
-    #[allow(clippy::arithmetic_side_effects)]
-    let remainder = nanos % factor;
-
-    // remainder <= nanos
-    #[allow(clippy::arithmetic_side_effects)]
-    let base = nanos - remainder;
-
-    #[allow(clippy::integer_division)]
-    let rounded = if remainder < factor / 2 {
-        base
-    } else {
-        // Worst case:
-        //     remainder = factor/2 - 1
-        //     input = Duration::MAX - factor/2 - 1
-        // FIXME think this through
-        base.checked_add(factor).unwrap()
-    };
-
-    nanos_to_duration(rounded)
-}
-
-/// Create a new [`Duration`] from a `u128` of nanoseconds.
-///
-/// This is essentially just [`Duration::from_nanos()`] but it works on a
-/// `u128`, which can represent any valid `Duration`.
-///
-/// # Panics
-///
-/// `Duration` can only represent 64 bits worth of seconds and less than 32 bits
-/// (1e9) worth of nanoseconds, which works out to being roughly 94 bits. A
-/// `u128` can therefore represent values that are invalid `Duration`s. This
-/// will panic in those cases.
-fn nanos_to_duration(total: u128) -> Duration {
-    /// Just to make things clear.
-    const NANOS_PER_SECOND: u128 = 1_000_000_000;
-    #[allow(clippy::integer_division)]
-    Duration::new(
-        (total / NANOS_PER_SECOND).try_into().expect(
-            "nanos_to_duration() overflowed seconds value for Duration",
-        ),
-        (total % NANOS_PER_SECOND).try_into().unwrap(),
-    )
 }
 
 impl fmt::Display for Timeout {
@@ -357,30 +286,6 @@ mod tests {
             requested: Duration::from_micros(microseconds),
             actual: Duration::from_micros(microseconds),
         }
-    }
-
-    /// Convenience constant for 1 millisecond.
-    const MS: Duration = Duration::from_millis(1);
-
-    #[test]
-    fn elapsed_rounded_up() {
-        check!(
-            expired_timeout(1_500).elapsed_rounded_to(MS).as_micros() == 2_000
-        );
-    }
-
-    #[test]
-    fn elapsed_rounded_exact() {
-        check!(
-            expired_timeout(2_000).elapsed_rounded_to(MS).as_micros() == 2_000
-        );
-    }
-
-    #[test]
-    fn elapsed_rounded_down() {
-        check!(
-            expired_timeout(2_499).elapsed_rounded_to(MS).as_micros() == 2_000
-        );
     }
 
     #[test]
@@ -516,99 +421,5 @@ mod tests {
     fn check_expired_timeout_expired() {
         let timeout = expired_timeout(5_000);
         check!(timeout.check_expired() == Some(timeout));
-    }
-
-    /// Convenient alias for [`Duration::from_millis()`].
-    const fn ms(ms: u64) -> Duration {
-        Duration::from_millis(ms)
-    }
-
-    #[test]
-    fn round_duration_ms_factor() {
-        check!(ms(10) == round_duration(ms(10), ms(1)));
-
-        check!(ms(10) == round_duration(ms(10), ms(2)));
-        check!(ms(10) == round_duration(ms(9), ms(2)));
-
-        check!(ms(9) == round_duration(ms(9), ms(3)));
-        check!(ms(9) == round_duration(ms(10), ms(3)));
-        check!(ms(12) == round_duration(ms(11), ms(3)));
-        check!(ms(12) == round_duration(ms(12), ms(3)));
-
-        // Round values > 1 second
-        check!(ms(1_010) == round_duration(ms(1_010), ms(1)));
-
-        check!(ms(1_010) == round_duration(ms(1_010), ms(2)));
-        check!(ms(1_010) == round_duration(ms(1_009), ms(2)));
-
-        check!(ms(1_008) == round_duration(ms(1_008), ms(3)));
-        check!(ms(1_008) == round_duration(ms(1_009), ms(3)));
-        check!(ms(1_011) == round_duration(ms(1_010), ms(3)));
-        check!(ms(1_011) == round_duration(ms(1_011), ms(3)));
-    }
-
-    #[test]
-    fn round_duration_second_factor() {
-        check!(ms(0) == round_duration(ms(499), ms(1_000)));
-        check!(ms(1_000) == round_duration(ms(500), ms(1_000)));
-        check!(ms(1_000) == round_duration(ms(1_010), ms(1_000)));
-        check!(ms(1_000) == round_duration(ms(1_499), ms(1_000)));
-        check!(ms(2_000) == round_duration(ms(1_500), ms(1_000)));
-
-        check!(ms(1_001) == round_duration(ms(1_000), ms(1_001)));
-        check!(ms(1_001) == round_duration(ms(1_001), ms(1_001)));
-        check!(ms(1_001) == round_duration(ms(1_002), ms(1_001)));
-    }
-
-    #[test]
-    fn round_duration_giant_factor() {
-        check!(ms(0) == round_duration(ms(1_000_000), Duration::MAX));
-        check!(Duration::MAX == round_duration(Duration::MAX, Duration::MAX));
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "assertion `left != right` failed: 0 is invalid factor for round_duration()\n"
-    )]
-    fn round_duration_zero_factor() {
-        round_duration(ms(10), ms(0));
-    }
-
-    /// Theoretical maximum Duration as nanoseconds (based on u64 for seconds).
-    const NANOS_MAX: u128 = u64::MAX as u128 * 1_000_000_000 + 999_999_999;
-
-    #[test]
-    #[allow(clippy::arithmetic_side_effects)]
-    fn nanos_to_duration_ok() {
-        check!(Duration::ZERO == nanos_to_duration(0));
-        check!(Duration::new(1, 1) == nanos_to_duration(1_000_000_001));
-
-        // Check Duration::MAX two ways, since according it its docs it can vary
-        // based on platform.
-        check!(Duration::MAX == nanos_to_duration(Duration::MAX.as_nanos()));
-        check!(
-            Duration::new(u64::MAX, 999_999_999)
-                == nanos_to_duration(NANOS_MAX)
-        );
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
-    )]
-    fn nanos_to_duration_overflow() {
-        nanos_to_duration(Duration::MAX.as_nanos() + 1);
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
-    )]
-    #[allow(clippy::arithmetic_side_effects)]
-    fn nanos_to_duration_overflow_manual() {
-        // One over the maximum duration. Just in case `Duration::MAX` is some
-        // other value, since the docs say it can vary by platform even if it
-        // currently is always `u64::MAX * 1_000_000_000 + 999_999_999`.
-        nanos_to_duration(NANOS_MAX + 1);
     }
 }

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -176,7 +176,10 @@ impl Timeout {
     }
 
     /// Calculate how much of the timeout has elapsed, rounded to the nearest
-    /// millisecond.
+    /// `factor` of time.
+    ///
+    /// For example, if `factor` is `Duration::from_millis(1)`, then it will
+    /// round the elapsed time to the nearest millisecond.
     ///
     /// [`Timeout::Never`] and [`Timeout::Future`] both always return
     /// [`Duration::ZERO`].
@@ -184,21 +187,8 @@ impl Timeout {
     /// This will not do anything special if called on a [`Timeout::Pending`]
     /// that has expired. See [`Timeout::check_expired()`].
     #[must_use]
-    pub fn elapsed_rounded(&self) -> Duration {
-        // FIXME: pass factor to round to?
-        let elapsed = self.elapsed();
-        let nanos: u32 = elapsed.subsec_nanos();
-        let sub_ms = nanos % 1_000_000;
-
-        // sub_ms is nanos % 1e6, so sub_ms <= nanos
-        #[allow(clippy::arithmetic_side_effects)]
-        let rounded = if sub_ms < 500_000 {
-            nanos - sub_ms
-        } else {
-            nanos + 1_000_000 - sub_ms
-        };
-
-        Duration::new(elapsed.as_secs(), rounded)
+    pub fn elapsed_rounded_to(&self, factor: Duration) -> Duration {
+        round_duration(self.elapsed(), factor)
     }
 
     /// Will this never time out?
@@ -208,6 +198,61 @@ impl Timeout {
     pub const fn is_never(&self) -> bool {
         matches!(self, Self::Never)
     }
+}
+
+/// Round a `Duration` to the nearest `factor`.
+///
+/// # Panics
+///
+/// Panics if `factor` is 0.
+#[inline]
+fn round_duration(input: Duration, factor: Duration) -> Duration {
+    let nanos = input.as_nanos();
+    let factor = factor.as_nanos();
+
+    assert_ne!(factor, 0, "0 is invalid factor for round_duration()");
+    #[allow(clippy::arithmetic_side_effects)]
+    let remainder = nanos % factor;
+
+    // remainder <= nanos
+    #[allow(clippy::arithmetic_side_effects)]
+    let base = nanos - remainder;
+
+    #[allow(clippy::integer_division)]
+    let rounded = if remainder < factor / 2 {
+        base
+    } else {
+        // Worst case:
+        //     remainder = factor/2 - 1
+        //     input = Duration::MAX - factor/2 - 1
+        // FIXME think this through
+        base.checked_add(factor).unwrap()
+    };
+
+    nanos_to_duration(rounded)
+}
+
+/// Create a new [`Duration`] from a `u128` of nanoseconds.
+///
+/// This is essentially just [`Duration::from_nanos()`] but it works on a
+/// `u128`, which can represent any valid `Duration`.
+///
+/// # Panics
+///
+/// `Duration` can only represent 64 bits worth of seconds and less than 32 bits
+/// (1e9) worth of nanoseconds, which works out to being roughly 94 bits. A
+/// `u128` can therefore represent values that are invalid `Duration`s. This
+/// will panic in those cases.
+fn nanos_to_duration(total: u128) -> Duration {
+    /// Just to make things clear.
+    const NANOS_PER_SECOND: u128 = 1_000_000_000;
+    #[allow(clippy::integer_division)]
+    Duration::new(
+        (total / NANOS_PER_SECOND).try_into().expect(
+            "nanos_to_duration() overflowed seconds value for Duration",
+        ),
+        (total % NANOS_PER_SECOND).try_into().unwrap(),
+    )
 }
 
 impl fmt::Display for Timeout {
@@ -314,19 +359,28 @@ mod tests {
         }
     }
 
+    /// Convenience constant for 1 millisecond.
+    const MS: Duration = Duration::from_millis(1);
+
     #[test]
     fn elapsed_rounded_up() {
-        check!(expired_timeout(1_500).elapsed_rounded().as_micros() == 2_000);
+        check!(
+            expired_timeout(1_500).elapsed_rounded_to(MS).as_micros() == 2_000
+        );
     }
 
     #[test]
     fn elapsed_rounded_exact() {
-        check!(expired_timeout(2_000).elapsed_rounded().as_micros() == 2_000);
+        check!(
+            expired_timeout(2_000).elapsed_rounded_to(MS).as_micros() == 2_000
+        );
     }
 
     #[test]
     fn elapsed_rounded_down() {
-        check!(expired_timeout(2_499).elapsed_rounded().as_micros() == 2_000);
+        check!(
+            expired_timeout(2_499).elapsed_rounded_to(MS).as_micros() == 2_000
+        );
     }
 
     #[test]
@@ -462,5 +516,99 @@ mod tests {
     fn check_expired_timeout_expired() {
         let timeout = expired_timeout(5_000);
         check!(timeout.check_expired() == Some(timeout));
+    }
+
+    /// Convenient alias for [`Duration::from_millis()`].
+    const fn ms(ms: u64) -> Duration {
+        Duration::from_millis(ms)
+    }
+
+    #[test]
+    fn round_duration_ms_factor() {
+        check!(ms(10) == round_duration(ms(10), ms(1)));
+
+        check!(ms(10) == round_duration(ms(10), ms(2)));
+        check!(ms(10) == round_duration(ms(9), ms(2)));
+
+        check!(ms(9) == round_duration(ms(9), ms(3)));
+        check!(ms(9) == round_duration(ms(10), ms(3)));
+        check!(ms(12) == round_duration(ms(11), ms(3)));
+        check!(ms(12) == round_duration(ms(12), ms(3)));
+
+        // Round values > 1 second
+        check!(ms(1_010) == round_duration(ms(1_010), ms(1)));
+
+        check!(ms(1_010) == round_duration(ms(1_010), ms(2)));
+        check!(ms(1_010) == round_duration(ms(1_009), ms(2)));
+
+        check!(ms(1_008) == round_duration(ms(1_008), ms(3)));
+        check!(ms(1_008) == round_duration(ms(1_009), ms(3)));
+        check!(ms(1_011) == round_duration(ms(1_010), ms(3)));
+        check!(ms(1_011) == round_duration(ms(1_011), ms(3)));
+    }
+
+    #[test]
+    fn round_duration_second_factor() {
+        check!(ms(0) == round_duration(ms(499), ms(1_000)));
+        check!(ms(1_000) == round_duration(ms(500), ms(1_000)));
+        check!(ms(1_000) == round_duration(ms(1_010), ms(1_000)));
+        check!(ms(1_000) == round_duration(ms(1_499), ms(1_000)));
+        check!(ms(2_000) == round_duration(ms(1_500), ms(1_000)));
+
+        check!(ms(1_001) == round_duration(ms(1_000), ms(1_001)));
+        check!(ms(1_001) == round_duration(ms(1_001), ms(1_001)));
+        check!(ms(1_001) == round_duration(ms(1_002), ms(1_001)));
+    }
+
+    #[test]
+    fn round_duration_giant_factor() {
+        check!(ms(0) == round_duration(ms(1_000_000), Duration::MAX));
+        check!(Duration::MAX == round_duration(Duration::MAX, Duration::MAX));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "assertion `left != right` failed: 0 is invalid factor for round_duration()\n"
+    )]
+    fn round_duration_zero_factor() {
+        round_duration(ms(10), ms(0));
+    }
+
+    /// Theoretical maximum Duration as nanoseconds (based on u64 for seconds).
+    const NANOS_MAX: u128 = u64::MAX as u128 * 1_000_000_000 + 999_999_999;
+
+    #[test]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn nanos_to_duration_ok() {
+        check!(Duration::ZERO == nanos_to_duration(0));
+        check!(Duration::new(1, 1) == nanos_to_duration(1_000_000_001));
+
+        // Check Duration::MAX two ways, since according it its docs it can vary
+        // based on platform.
+        check!(Duration::MAX == nanos_to_duration(Duration::MAX.as_nanos()));
+        check!(
+            Duration::new(u64::MAX, 999_999_999)
+                == nanos_to_duration(NANOS_MAX)
+        );
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
+    )]
+    fn nanos_to_duration_overflow() {
+        nanos_to_duration(Duration::MAX.as_nanos() + 1);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "nanos_to_duration() overflowed seconds value for Duration: TryFromIntError(())"
+    )]
+    #[allow(clippy::arithmetic_side_effects)]
+    fn nanos_to_duration_overflow_manual() {
+        // One over the maximum duration. Just in case `Duration::MAX` is some
+        // other value, since the docs say it can vary by platform even if it
+        // currently is always `u64::MAX * 1_000_000_000 + 999_999_999`.
+        nanos_to_duration(NANOS_MAX + 1);
     }
 }


### PR DESCRIPTION
Previously, `Timeout::elapsed_rounded()` was hard coded to round to the nearest millisecond. This renames the function and adds a parameter to specify what factor the duration should be rounded to.

For example, `timeout.elapsed_rounded_to(Duration::from_millis(1))` returns the elapsed time rounded to the nearest millisecond.

This also adds a private function to round `Duration`s more generally, and a private function to create a `Duration` from `u128` of nanoseconds (`Duration::from_nanos()` takes a `u64`).