### PR TITLE
Switch shell-words to shlex for lossless escaping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "nom",
  "popol",
  "regex",
- "shell-words",
+ "shlex",
  "simplelog",
  "tempfile",
  "termcolor",
@@ -534,10 +534,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 
 [[package]]
-name = "shell-words"
-version = "1.1.0"
+name = "shlex"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "simplelog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.14"
 nix = { version = "0.26.1", default-features = false, features = ["signal", "process"] }
 nom = "7.1.3"
 popol = "3.0.0"
-shell-words = "1.1.0"
+shlex = "1.2.0"
 simplelog = "0.12.0"
 termcolor = "1.1.3"
 thiserror = "1.0.40"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@
 #![forbid(unsafe_code)]
 
 use anyhow::{bail, Context};
+use bstr::ByteSlice;
 use clap::Parser;
 use cron_wrapper::command::{Command, Event};
 use cron_wrapper::job_logger::{Destination, JobLogger};
@@ -118,7 +119,10 @@ fn start(params: &Params, job_logger: &mut JobLogger) -> anyhow::Result<i32> {
                     println!("Exited with code {code}");
                 }
 
-                info!("Exit with {code}: {}", command.command_line_sh());
+                info!(
+                    "Exit with {code}: {}",
+                    command.command_line_sh().as_bstr()
+                );
                 return Ok(code);
             }
             Event::Error(error) => {


### PR DESCRIPTION
I contributed support for working on byte strings to [shlex], so this uses that support to losslessly escape command lines.

[shlex]: https://crates.io/crates/shlex