### PR TITLE
Log human version of errors

### DIFF
--- a/src/job_logger/logger.rs
+++ b/src/job_logger/logger.rs
@@ -247,7 +247,7 @@ impl JobLogger {
         &mut self,
         error: &anyhow::Error,
     ) -> Result<(), Error> {
-        self.write_record(Kind::WrapperError, format!("{error:?}").as_bytes())
+        self.write_record(Kind::WrapperError, error.to_string().as_bytes())
     }
 
     /// Log an [`Event`] received from the [`Child`].
@@ -267,7 +267,7 @@ impl JobLogger {
                 }
             }
             Event::Error(error) => {
-                self.write_record(Kind::Error, format!("{error:?}").as_bytes())
+                self.write_record(Kind::Error, error.to_string().as_bytes())
             }
         }
     }
@@ -937,7 +937,7 @@ mod tests {
         //     Start: 2023-05-19T22:17:04.858177000-07:00
         //
         //     0.000 out abc
-        //     0.000 ERROR IdleTimeout { ... }
+        //     0.000 ERROR Timed out waiting for input after 0ns
         //     0.000 out def
         //
         check_output(
@@ -945,7 +945,7 @@ mod tests {
             "^Start: <date>T<time+>\n\
             \n\
             \\d\\.\\d{3} out abc\n\
-            \\d\\.\\d{3} ERROR IdleTimeout.*?\n\
+            \\d\\.\\d{3} ERROR Timed out waiting for input after 0ns\n\
             \\d\\.\\d{3} out def\n$",
         );
     }
@@ -963,7 +963,7 @@ mod tests {
         //     Start: 2023-05-19T22:17:04.858177000-07:00
         //
         //     0.000 out abc\
-        //     0.000 ERROR IdleTimeout { ... }
+        //     0.000 ERROR Timed out waiting for input after 0ns
         //     0.000 out def
         //
         check_output(
@@ -971,7 +971,7 @@ mod tests {
             "^Start: <date>T<time+>\n\
             \n\
             \\d\\.\\d{3} out abc\\\\\n\
-            \\d\\.\\d{3} ERROR IdleTimeout \\{.*?\\}\n\
+            \\d\\.\\d{3} ERROR Timed out waiting for input after 0ns\n\
             \\d\\.\\d{3} out def\n$",
         );
     }

--- a/tests/fixtures/output/stdouterr-idle-timeout.out
+++ b/tests/fixtures/output/stdouterr-idle-timeout.out
@@ -1,8 +1,8 @@
 Command: ["tests/fixtures/stdouterr.sh"]
-Start: 2023-07-26T13:32:00.259549000-07:00
+Start: 2023-09-10T22:01:18.296574000-07:00
 
 0.003 out 01 stdout
-          02 stdout
+0.003 out 02 stdout
 0.003 err 03 STDERR
           04 STDERR sleep 0.1
-0.053 ERROR IdleTimeout { timeout: Expired { requested: 50ms, actual: 50.078023ms } }
+0.053 ERROR Timed out waiting for input after 50ms

--- a/tests/fixtures/output/stdouterr-run-timeout.out
+++ b/tests/fixtures/output/stdouterr-run-timeout.out
@@ -1,12 +1,12 @@
 Command: ["tests/fixtures/stdouterr.sh"]
-Start: 2023-07-26T13:30:52.377328000-07:00
+Start: 2023-09-10T21:57:00.328874000-07:00
 
-0.004 out 01 stdout
-0.004 out 02 stdout
-0.004 err 03 STDERR
+0.007 out 01 stdout
+          02 stdout
+0.007 err 03 STDERR
           04 STDERR sleep 0.1
-0.111 out 05 stdout sleep 0.1
-0.217 out 07 stdout \
-0.217 err 06 STDERR 08 STDERR
+0.110 out 05 stdout sleep 0.1
+0.220 out 07 stdout \
+0.220 err 06 STDERR 08 STDERR
           09 STDERR sleep 0.2 \
-0.301 ERROR RunTimeout { timeout: Expired { requested: 300ms, actual: 300.699222ms } }
+0.302 ERROR Run timed out after 301ms


### PR DESCRIPTION
Instead of trying to serialize the an error object to write it to a structured log and then deserialize it when replaying, just write the human version of the error to the structured log in the first place.

This is the good enough solution.