### PR TITLE
Security: update rustix and shlex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,9 +276,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "instant"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 
 [[package]]
 name = "shlex"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simplelog"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4.14"
 nix = { version = "0.26.1", default-features = false, features = ["signal", "process"] }
 nom = "7.1.3"
 popol = "3.0.0"
-shlex = "1.2.0"
+shlex = "1.3.0"
 simplelog = "0.12.0"
 termcolor = "1.1.3"
 thiserror = "1.0.40"

--- a/src/command.rs
+++ b/src/command.rs
@@ -499,9 +499,21 @@ impl Command {
     }
 
     /// Get the command line to run escaped for the shell.
+    ///
+    /// Note that this might return a literal \0 in its return if it is present
+    /// in the command or its arguments.
+    ///
+    /// # Panics
+    ///
+    /// This should not panic with shlex version 1.3.0. However, future version
+    /// of shlex may introduce new ways of quoting that may fail.
     #[must_use]
     pub fn command_line_sh(&self) -> Vec<u8> {
-        shlex::bytes::join(self.command_line().map(|word| word.as_bytes()))
+        // This cannot fail in shlex 1.3.0:
+        shlex::bytes::Quoter::new()
+            .allow_nul(true)
+            .join(self.command_line().map(|word| word.as_bytes()))
+            .unwrap()
     }
 }
 


### PR DESCRIPTION
Resolves two security alerts:

* **High:** shlex didn’t properly escape certain characters. We only use shell escaping in log messages. ([GHSA-r7qv-8r2h-pg27](https://github.com/advisories/GHSA-r7qv-8r2h-pg27))
* **Moderate:** rustix could rapidly use all available memory when iterating over a directory. I don’t believe this affected cron-wrapper. ([GHSA-c827-hfw6-qwvm](https://github.com/advisories/GHSA-c827-hfw6-qwvm))

This also updates hermit-abi to a non-yanked version.