### PR TITLE
Option to combine output streams into one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -199,6 +199,7 @@ dependencies = [
  "log",
  "nix",
  "nom",
+ "os_pipe",
  "popol",
  "regex",
  "shlex",
@@ -246,7 +247,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -297,7 +298,7 @@ checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -309,7 +310,7 @@ dependencies = [
  "hermit-abi",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -402,6 +403,16 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "os_pipe"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57119c3b893986491ec9aa85056780d3a0f3cf4da7cc09dd3650dbd6c6738fb9"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "popol"
@@ -518,7 +529,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -595,7 +606,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -720,7 +731,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -729,13 +749,28 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -745,10 +780,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -757,10 +804,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -769,16 +828,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ is-terminal = "0.4.7"
 log = "0.4.14"
 nix = { version = "0.26.1", default-features = false, features = ["signal", "process"] }
 nom = "7.1.3"
+os_pipe = "1.1.5"
 popol = "3.0.0"
 shlex = "1.3.0"
 simplelog = "0.12.0"

--- a/src/actions/replay.rs
+++ b/src/actions/replay.rs
@@ -35,7 +35,7 @@ pub fn replay(global: &Params, params: &ReplayParams) -> anyhow::Result<i32> {
 
     for record in records {
         match record.kind {
-            Kind::Stdout => {
+            Kind::Stdout | Kind::Combined => {
                 out.write_all(&record.value)?;
                 out.flush()?;
             }

--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -43,6 +43,7 @@ fn start(
     let command = Command {
         command: params.command.clone().into(),
         args: params.args.clone(),
+        combine_streams: params.combine_output,
         run_timeout: params.run_timeout.into(),
         idle_timeout: params.idle_timeout.into(),
         buffer_size: params.buffer_size,
@@ -66,7 +67,7 @@ fn start(
     while let Some(event) = child.next_event() {
         job_logger.log_event(&event)?;
         match event {
-            Event::Stdout(output) => {
+            Event::Stdout(output) | Event::Combined(output) => {
                 if !output.is_empty() && params.normal_output_enabled() {
                     let mut out = out.borrow_mut();
                     out.write_all(output)?;

--- a/src/job_logger/logger.rs
+++ b/src/job_logger/logger.rs
@@ -257,6 +257,9 @@ impl JobLogger {
     /// This will return an error if it can’t write to the log.
     pub fn log_event(&mut self, event: &Event) -> Result<(), Error> {
         match &event {
+            Event::Combined(output) => {
+                self.write_record(Kind::Combined, output)
+            }
             Event::Stdout(output) => self.write_record(Kind::Stdout, output),
             Event::Stderr(output) => self.write_record(Kind::Stderr, output),
             Event::Exit(_) => {

--- a/src/job_logger/mod.rs
+++ b/src/job_logger/mod.rs
@@ -23,6 +23,9 @@ pub use logger::*;
 /// [`Event::Error`]: crate::command::Event::Error
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Kind {
+    /// Output on the child process’s combined stdout + stderr stream.
+    Combined,
+
     /// Output on the child process’s stdout.
     Stdout,
 
@@ -44,6 +47,7 @@ impl Kind {
     #[must_use]
     pub const fn as_bytes(self) -> &'static [u8] {
         match self {
+            Self::Combined => b"com",
             Self::Stdout => b"out",
             Self::Stderr => b"err",
             Self::Exit => b"exit",
@@ -52,10 +56,10 @@ impl Kind {
         }
     }
 
-    /// Is this an output (stdout or stderr)?
+    /// Is this an output (combined, stdout, or stderr)?
     #[must_use]
     pub const fn is_output(self) -> bool {
-        matches!(self, Self::Stdout | Self::Stderr)
+        matches!(self, Self::Combined | Self::Stdout | Self::Stderr)
     }
 
     /// Is this an error (stderr, error, wrapper-error)?

--- a/src/job_logger/parser.rs
+++ b/src/job_logger/parser.rs
@@ -119,6 +119,7 @@ where
     let kind_parser = delimited(
         is_a(" "),
         alt((
+            value(Kind::Combined, tag("com")),
             value(Kind::Stdout, tag("out")),
             value(Kind::Stderr, tag("err")),
             value(Kind::Exit, tag("exit")),

--- a/src/params.rs
+++ b/src/params.rs
@@ -105,6 +105,14 @@ pub struct RunParams {
     #[clap(short = 'X', long)]
     pub show_fail_code: bool,
 
+    /// Combine stdout and stderr output
+    ///
+    /// Separate streams can sometimes be read out of order when writes occur
+    /// very close together. Combining the streams solves those problems, but
+    /// prevents us from determining what is on stdout and what is on stderr.
+    #[clap(short = 'C', long)]
+    pub combine_output: bool,
+
     /// Store structured log files in DIRECTORY
     ///
     /// Log files will be named YYYY-mm-ddTHH:MM:SS-ZZ:ZZ.$command.$pid.log. For

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -130,6 +130,38 @@ fn mixed_output_on_fail_color() {
 }
 
 #[test]
+fn combined_output() {
+    let output = helpers::run([
+        "run",
+        "--combine-output",
+        "tests/fixtures/mixed_output.sh",
+    ])
+    .output()
+    .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111aaa333\nbbb\n");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
+fn combined_output_unconditional_color() {
+    let output = helpers::run([
+        "--color",
+        "always",
+        "run",
+        "--combine-output",
+        "tests/fixtures/mixed_output.sh",
+    ])
+    .output()
+    .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111aaa333\nbbb\n");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
 fn invalid_utf8() {
     let output = helpers::run(["run", "tests/fixtures/invalid_utf8.sh"])
         .output()


### PR DESCRIPTION
Sometimes it’s more important for the output order to be correct than to separate what’s error and what’s normal output.

Fixes #92.