### PR TITLE
Add `--lock-file PATH` option to `run`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
 name = "bstr"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,7 +162,7 @@ checksum = "2c9b4a88bb4bc35d3d6f65a21b0f0bafe9c894fa00978de242c555ec28bea1c0"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
@@ -195,6 +201,7 @@ dependencies = [
  "bstr",
  "clap",
  "duration-str",
+ "fd-lock",
  "is-terminal",
  "log",
  "nix",
@@ -270,6 +277,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix 0.38.13",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,7 +327,7 @@ checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi",
  "io-lifetimes",
- "rustix",
+ "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
 
@@ -341,6 +359,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,7 +388,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "static_assertions",
@@ -475,7 +499,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -524,11 +548,24 @@ version = "0.37.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4eb579851244c2c03e7c24f501c3432bed80b8f720af1d6e5b0e0f01555a035"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+dependencies = [
+ "bitflags 2.4.2",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.13",
  "windows-sys 0.48.0",
 ]
 
@@ -605,7 +642,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.37.25",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,10 @@ rust-version = "1.65"
 
 [dependencies]
 anyhow = "1.0.44"
-bstr = { version = "1.1.0", default-features = false }
+bstr = { version = "1.1.0", default-features = false, features = ["alloc"] }
 clap = { version = "4.0.18", features = ["derive"] }
 duration-str = { version = "0.5.0", default-features = false }
+fd-lock = "4.0.2"
 is-terminal = "0.4.7"
 log = "0.4.14"
 nix = { version = "0.26.1", default-features = false, features = ["signal", "process"] }
@@ -84,3 +85,6 @@ let_underscore_untyped = "allow"
 manual_string_new = "allow"
 map_unwrap_or = "allow"
 module_name_repetitions = "allow"
+
+# Nursery exceptions
+option_if_let_else = "allow"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@
 
 pub mod command;
 pub mod job_logger;
+pub mod lock;
 pub mod pause_writer;
 pub mod timeout;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,186 @@
+//! # Functions to manage file locks
+
+use bstr::{BString, ByteSlice};
+use fd_lock::{RwLock, RwLockWriteGuard};
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, ErrorKind, Read, Seek, Write};
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::process;
+
+/// Errors establishing a lock might raise.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error reading the lock file before getting the lock.
+    #[error("Could read lock file: {0}")]
+    Read(io::Error),
+
+    /// Error getting the lock on the lock file..
+    #[error("Could establish lock: {0}")]
+    Lock(io::Error),
+
+    /// Call to get a lock was interrupted by a signal repeatedly.
+    #[error("Interupted {attempts} times trying to get lock")]
+    LockInterupted {
+        /// How many times the attempt to establish a lock was interupted.
+        attempts: usize,
+    },
+
+    /// The lock was already owned by another process.
+    #[error("Lock owned by another process:\n{contents}")]
+    AlreadyRunning {
+        /// The contents of the lock file.
+        contents: BString,
+    },
+}
+
+/// Open a lock file to ensure `func` is only run once.
+///
+/// # Errors
+///
+/// See [`Error`]. This can return an error from the inner function, too.
+pub fn try_lock_raw<P, R, F>(path: P, func: F) -> anyhow::Result<R>
+where
+    P: AsRef<Path>,
+    F: FnOnce(RwLockWriteGuard<'_, fs::File>) -> anyhow::Result<R>,
+{
+    /// Only retry locking after a signal interruption this many times.
+    const ATTEMPTS: usize = 10;
+
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(path.as_ref())
+        .map_err(Error::Read)?;
+    let mut contents = BString::new(vec![]);
+    #[allow(clippy::verbose_file_reads)] // Need to keep file open.
+    file.read_to_end(&mut contents).map_err(Error::Read)?;
+
+    let mut lock = RwLock::new(file);
+
+    for _ in 0..ATTEMPTS {
+        return match lock.try_write() {
+            Ok(guard) => func(guard),
+            Err(error) => match error.kind() {
+                ErrorKind::WouldBlock => {
+                    Err(Error::AlreadyRunning { contents }.into())
+                }
+                ErrorKind::Interrupted => {
+                    // Try again
+                    continue;
+                }
+                _ => Err(Error::Lock(error).into()),
+            },
+        };
+    }
+
+    Err(Error::LockInterupted { attempts: ATTEMPTS }.into())
+}
+
+/// Open a lock file to ensure `func` is only run once. This writes the standard
+/// message to the lock file if it manages to obtain it.
+///
+/// # Errors
+///
+/// See [`Error`]. This can return an error from the inner function, too.
+pub fn try_lock_standard<P, R, F>(path: P, func: F) -> anyhow::Result<R>
+where
+    P: AsRef<Path>,
+    F: FnOnce() -> anyhow::Result<R>,
+{
+    try_lock_raw(path, |mut guard| {
+        guard.set_len(0)?;
+        guard.rewind()?;
+        writeln!(guard, "COMMAND={}", args_sh().as_bstr())?;
+        writeln!(guard, "PID={}", process::id())?;
+        func()
+    })
+}
+
+/// Get the command line for this run escaped for the shell.
+///
+/// Note that this might return a literal \0 in its return if it is present
+/// in the command or its arguments.
+///
+/// # Panics
+///
+/// This should not panic with shlex version 1.3.0. However, future version
+/// of shlex may introduce new ways of quoting that may fail.
+#[must_use]
+pub fn args_sh() -> Vec<u8> {
+    let args: Vec<OsString> = env::args_os().collect();
+    let args_bytes = args.iter().map(|arg| arg.as_bytes());
+
+    // This cannot fail in shlex 1.3.0:
+    shlex::bytes::Quoter::new()
+        .allow_nul(true)
+        .join(args_bytes)
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use assert2::{check, let_assert};
+    use tempfile::tempdir;
+
+    #[test]
+    fn try_lock_raw_basic() {
+        let directory = tempdir().unwrap();
+        let foo_file = directory.path().join("foo");
+
+        // Check that creating a file works.
+        let_assert!(
+            Ok(()) = try_lock_raw(&foo_file, |mut guard| {
+                guard.set_len(0)?;
+                guard.rewind()?;
+                writeln!(guard, "Ok")?;
+                Ok(())
+            })
+        );
+
+        let_assert!(Ok(contents) = fs::read(&foo_file));
+        check!(contents.as_bstr() == b"Ok\n".as_bstr());
+
+        // Check that using the file a second time works.
+        let_assert!(
+            Ok(()) = try_lock_raw(&foo_file, |mut guard| {
+                guard.set_len(0)?;
+                guard.rewind()?;
+                writeln!(guard, "2")?;
+                Ok(())
+            })
+        );
+
+        let_assert!(Ok(contents) = fs::read(&foo_file));
+        check!(contents.as_bstr() == b"2\n".as_bstr());
+    }
+
+    #[allow(clippy::naive_bytecount)] // Overkill for this case.
+    #[test]
+    fn try_lock_standard_basic() {
+        let directory = tempdir().unwrap();
+        let foo_file = directory.path().join("foo");
+
+        // Check that creating a file works.
+        let_assert!(Ok(()) = try_lock_standard(&foo_file, || { Ok(()) }));
+
+        let_assert!(Ok(contents) = fs::read(&foo_file));
+        check!(
+            contents.iter().filter(|&c| *c == b'\n').count() == 2,
+            "expected contents to have 2 newlines"
+        );
+
+        // Check that using the file a second time works.
+        let_assert!(Ok(()) = try_lock_standard(&foo_file, || { Ok(()) }));
+
+        let_assert!(Ok(contents) = fs::read(&foo_file));
+        check!(
+            contents.iter().filter(|&c| *c == b'\n').count() == 2,
+            "expected contents to have 2 newlines"
+        );
+    }
+}

--- a/src/params.rs
+++ b/src/params.rs
@@ -175,6 +175,14 @@ pub struct RunParams {
     #[clap(long, default_value = "SIGTERM", value_name = "SIGNAL")]
     pub error_signal: OptionalSignal,
 
+    /// Ensure that only one copy of this command is running at once.
+    ///
+    /// Specifies the lock file to use to ensure that only one copy of this
+    /// command is running at once. If a process is already using the file, the
+    /// file contents will be printed and we will immediately exit.
+    #[clap(long, value_name = "FILE")]
+    pub lock_file: Option<PathBuf>,
+
     /// Hidden: how large a buffer to use
     #[clap(
         long,

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -1,0 +1,43 @@
+use assert2::check;
+use bstr::ByteSlice;
+use std::thread;
+use std::time::Duration;
+use tempfile::NamedTempFile;
+
+mod helpers;
+
+#[test]
+fn lock_conflict() {
+    let lock_path_handle = NamedTempFile::new().unwrap().into_temp_path();
+    let lock_path = lock_path_handle.to_path_buf();
+    let lock_path2 = lock_path_handle.to_path_buf();
+
+    let handle = thread::spawn(move || {
+        let output = helpers::run(["run", "--lock-file"])
+            .arg(&lock_path)
+            .args(["sleep", "0.5"])
+            .output()
+            .unwrap();
+        check!(output.status.success());
+        check!(output.stdout.as_bstr() == "");
+        check!(output.stderr.as_bstr() == "");
+    });
+
+    thread::sleep(Duration::from_millis(100));
+
+    let handle2 = thread::spawn(move || {
+        let output = helpers::run(["run", "--lock-file"])
+            .arg(&lock_path2)
+            .args(["sleep", "0.5"])
+            .output()
+            .unwrap();
+        check!(!output.status.success(), "Should fail to obtain lock");
+        check!(output.stdout.as_bstr() == "");
+        check!(output
+            .stderr
+            .starts_with(b"Error: Lock owned by another process"));
+    });
+
+    handle.join().unwrap();
+    handle2.join().unwrap();
+}


### PR DESCRIPTION
This causes `cron-wrapper` to generate a lock file and fail fast if the lock file is already locked by another process.

Part of #91 — Option to ensure only one job is run at once.