### PR TITLE
Clippy +nightly: clarify `OpenOptions` options

### DIFF
--- a/src/lock.rs
+++ b/src/lock.rs
@@ -53,6 +53,7 @@ where
         .read(true)
         .write(true)
         .create(true)
+        .truncate(false)
         .open(path.as_ref())
         .map_err(Error::Read)?;
     let mut contents = BString::new(vec![]);


### PR DESCRIPTION
Clarify that opening lock file for writing (and reading) should not truncate it.