### PR TITLE
Fix lint priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ unsafe_code = "forbid"
 missing_docs = "warn"
 
 [workspace.lints.clippy]
-nursery = "warn"
-pedantic = "warn"
+nursery = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
 missing_docs_in_private_items = "warn"
 
 # Other restriction lints

--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -37,7 +37,6 @@ pub fn run(global: &Params, params: &RunParams) -> anyhow::Result<i32> {
         })
     }
 
-    #[allow(clippy::option_if_let_else)] // FIXME doesn’t work in Cargo.toml?
     match &params.lock_file {
         Some(path) => try_lock_standard(path, || inner(global, params)),
         None => inner(global, params),


### PR DESCRIPTION
Lint rules in the `[lints]` table are not applied in file order. This could cause certain rules to be ignored if they were applied before the rule that effects the group they were in. For example, if `clippy::nursery` and `clippy::option_if_let_else` have the same priority, then `nursery` gets applied after `option_if_let_else`, causing the more specific rule to be ignored.

This explicitly sets `nursery` and `pedantic` to priority -1 so that they are overridden by more specific rules (which are priority 0 by default).

Resolves same issue as #100 (Use `lints.toml` instead of `[lints]` table in `Cargo.toml`).