### PR TITLE
Add `paused` parameter to `PausableWriter::stdout()`

### DIFF
--- a/src/actions/run.rs
+++ b/src/actions/run.rs
@@ -122,8 +122,8 @@ fn start(
 
     let out = Rc::new(RefCell::new(PausableWriter::stdout(
         global.out_color_choice(),
+        params.start_paused(),
     )));
-    out.borrow_mut().set_paused(params.start_paused())?;
 
     if params.log_stdout {
         job_logger.add_destination(Destination::ColorStream(out.clone()));

--- a/src/pause_writer.rs
+++ b/src/pause_writer.rs
@@ -36,12 +36,12 @@ pub struct PausableWriter {
 impl PausableWriter {
     /// Create a new paused `PausableWriter` for stdout
     #[must_use]
-    pub fn stdout(color_choice: ColorChoice) -> Self {
+    pub fn stdout(color_choice: ColorChoice, paused: bool) -> Self {
         let buffer_writer = BufferWriter::stdout(color_choice);
         let buffer = buffer_writer.buffer();
         Self {
-            paused: true,
             writer: StandardStream::stdout(color_choice),
+            paused,
             buffer_writer,
             buffer,
         }


### PR DESCRIPTION
Previously, if you wanted to start `PausableWriter` unpaused you had to call a function that could return an error. In practice the buffer would be empty so the IO code didn’t actually need to be called. This adds a `paused` parameter to the constructor to avoid the whole problem.