### PR TITLE
Remove `Timeout::elapsed_rounded()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ dependencies = [
  "os_pipe",
  "popol",
  "regex",
+ "roundable",
  "shlex",
  "simplelog",
  "tempfile",
@@ -527,6 +528,12 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "roundable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60737ef89010387220203ffe33ff361b27a55cd5b6e80eb6bb226c443af07090"
 
 [[package]]
 name = "rust_decimal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ nix = { version = "0.26.1", default-features = false, features = ["signal", "pro
 nom = "7.1.3"
 os_pipe = "1.1.5"
 popol = "3.0.0"
+roundable = "0.1.0"
 shlex = "1.3.0"
 simplelog = "0.12.0"
 termcolor = "1.1.3"

--- a/src/command.rs
+++ b/src/command.rs
@@ -16,6 +16,7 @@ use bstr::ByteSlice;
 use log::{debug, error, info, trace};
 use os_pipe::{pipe, PipeReader};
 use popol::{interest, set_nonblocking};
+use roundable::{Roundable, MILLISECOND};
 use std::cmp;
 use std::collections::VecDeque;
 use std::ffi::OsString;
@@ -120,14 +121,20 @@ pub enum Error {
     },
 
     /// The idle timeout elapsed waiting for input in `poll()`.
-    #[error("Timed out waiting for input after {:?}", timeout.elapsed_rounded())]
+    #[error(
+        "Timed out waiting for input after {:?}",
+        timeout.elapsed().round_to(MILLISECOND)
+    )]
     IdleTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,
     },
 
     /// The run timeout elapsed.
-    #[error("Run timed out after {:?}", timeout.elapsed_rounded())]
+    #[error(
+        "Run timed out after {:?}",
+        timeout.elapsed().round_to(MILLISECOND)
+    )]
     RunTimeout {
         /// Information about the timeout in the form of [`Timeout::Expired`].
         timeout: Timeout,

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -175,32 +175,6 @@ impl Timeout {
         }
     }
 
-    /// Calculate how much of the timeout has elapsed, rounded to the nearest
-    /// millisecond.
-    ///
-    /// [`Timeout::Never`] and [`Timeout::Future`] both always return
-    /// [`Duration::ZERO`].
-    ///
-    /// This will not do anything special if called on a [`Timeout::Pending`]
-    /// that has expired. See [`Timeout::check_expired()`].
-    #[must_use]
-    pub fn elapsed_rounded(&self) -> Duration {
-        // FIXME: pass factor to round to?
-        let elapsed = self.elapsed();
-        let nanos: u32 = elapsed.subsec_nanos();
-        let sub_ms = nanos % 1_000_000;
-
-        // sub_ms is nanos % 1e6, so sub_ms <= nanos
-        #[allow(clippy::arithmetic_side_effects)]
-        let rounded = if sub_ms < 500_000 {
-            nanos - sub_ms
-        } else {
-            nanos + 1_000_000 - sub_ms
-        };
-
-        Duration::new(elapsed.as_secs(), rounded)
-    }
-
     /// Will this never time out?
     ///
     /// Returns `true` for [`Timeout::Never`] and `false` for everything else.
@@ -312,21 +286,6 @@ mod tests {
             requested: Duration::from_micros(microseconds),
             actual: Duration::from_micros(microseconds),
         }
-    }
-
-    #[test]
-    fn elapsed_rounded_up() {
-        check!(expired_timeout(1_500).elapsed_rounded().as_micros() == 2_000);
-    }
-
-    #[test]
-    fn elapsed_rounded_exact() {
-        check!(expired_timeout(2_000).elapsed_rounded().as_micros() == 2_000);
-    }
-
-    #[test]
-    fn elapsed_rounded_down() {
-        check!(expired_timeout(2_499).elapsed_rounded().as_micros() == 2_000);
     }
 
     #[test]


### PR DESCRIPTION
Previously, `Timeout::elapsed_rounded()` was provided because it was inconvenient to round `Duration`s. The new [`roundable`] crate makes it easy, so this removes `Timeout::elapsed_rounded()`.

[`roundable`]: https://crates.io/crates/roundable